### PR TITLE
Improve record/replay fidelity runtime

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,11 +14,32 @@ endif()
 set(HL2SDK $ENV{HL2SDKCS2})
 set(MMS    $ENV{MMSOURCE_DEV})
 set(PROTO_DIR $ENV{CSGO_PROTO})
-foreach(v HL2SDK MMS PROTO_DIR)
+foreach(v HL2SDK MMS)
     if(NOT ${v} OR NOT EXISTS "${${v}}")
         message(FATAL_ERROR "${v} env var not set or path missing: '${${v}}'")
     endif()
 endforeach()
+
+if(NOT PROTO_DIR OR NOT EXISTS "${PROTO_DIR}/network_connection.proto" OR
+   NOT EXISTS "${PROTO_DIR}/networkbasetypes.proto" OR
+   NOT EXISTS "${PROTO_DIR}/usercmd.proto" OR
+   NOT EXISTS "${PROTO_DIR}/cs_usercmd.proto")
+    set(PROTO_STAGE "${CMAKE_BINARY_DIR}/proto_stage")
+    file(MAKE_DIRECTORY "${PROTO_STAGE}")
+    set(PROTO_SOURCE_FILES
+        "${HL2SDK}/common/network_connection.proto"
+        "${HL2SDK}/common/networkbasetypes.proto"
+        "${HL2SDK}/game/shared/usercmd.proto"
+        "${HL2SDK}/game/shared/cs/cs_usercmd.proto")
+    foreach(src ${PROTO_SOURCE_FILES})
+        if(NOT EXISTS "${src}")
+            message(FATAL_ERROR "required CS2 proto missing: ${src}")
+        endif()
+        get_filename_component(proto_name "${src}" NAME)
+        configure_file("${src}" "${PROTO_STAGE}/${proto_name}" COPYONLY)
+    endforeach()
+    set(PROTO_DIR "${PROTO_STAGE}")
+endif()
 
 # eiface.h needs network_connection.pb.h; the usercmd protos give us
 # CSGOUserCmdPB / CSubtickMoveStep for subtick record + replay.
@@ -87,17 +108,48 @@ add_custom_command(
     VERBATIM
 )
 
-include(FetchContent)
-set(FUNCHOOK_BUILD_TESTS OFF CACHE BOOL "" FORCE)
-set(FUNCHOOK_BUILD_SHARED OFF CACHE BOOL "" FORCE)
-if(DEFINED ENV{FUNCHOOK_SOURCE} AND EXISTS "$ENV{FUNCHOOK_SOURCE}/CMakeLists.txt")
-    set(FETCHCONTENT_SOURCE_DIR_FUNCHOOK "$ENV{FUNCHOOK_SOURCE}" CACHE PATH "")
+if(DEFINED ENV{FUNCHOOK_ROOT} AND EXISTS "$ENV{FUNCHOOK_ROOT}/include/funchook.h")
+    add_library(funchook-static STATIC IMPORTED GLOBAL)
+    add_library(distorm-static STATIC IMPORTED GLOBAL)
+    set_target_properties(funchook-static PROPERTIES
+        INTERFACE_INCLUDE_DIRECTORIES "$ENV{FUNCHOOK_ROOT}/include"
+        INTERFACE_LINK_LIBRARIES distorm-static)
+    if(WIN32)
+        set_target_properties(funchook-static PROPERTIES
+            IMPORTED_LOCATION_RELEASE "$ENV{FUNCHOOK_ROOT}/lib/Release/funchook.lib"
+            IMPORTED_LOCATION_RELWITHDEBINFO "$ENV{FUNCHOOK_ROOT}/lib/Release/funchook.lib"
+            IMPORTED_LOCATION_MINSIZEREL "$ENV{FUNCHOOK_ROOT}/lib/Release/funchook.lib"
+            IMPORTED_LOCATION_DEBUG "$ENV{FUNCHOOK_ROOT}/lib/Debug/funchook.lib")
+        set_target_properties(distorm-static PROPERTIES
+            IMPORTED_LOCATION_RELEASE "$ENV{FUNCHOOK_ROOT}/lib/Release/distorm.lib"
+            IMPORTED_LOCATION_RELWITHDEBINFO "$ENV{FUNCHOOK_ROOT}/lib/Release/distorm.lib"
+            IMPORTED_LOCATION_MINSIZEREL "$ENV{FUNCHOOK_ROOT}/lib/Release/distorm.lib"
+            IMPORTED_LOCATION_DEBUG "$ENV{FUNCHOOK_ROOT}/lib/Debug/distorm.lib")
+    else()
+        set_target_properties(funchook-static PROPERTIES
+            IMPORTED_LOCATION_RELEASE "$ENV{FUNCHOOK_ROOT}/lib/Release/libfunchook.a"
+            IMPORTED_LOCATION_RELWITHDEBINFO "$ENV{FUNCHOOK_ROOT}/lib/Release/libfunchook.a"
+            IMPORTED_LOCATION_MINSIZEREL "$ENV{FUNCHOOK_ROOT}/lib/Release/libfunchook.a"
+            IMPORTED_LOCATION_DEBUG "$ENV{FUNCHOOK_ROOT}/lib/Debug/libfunchook.a")
+        set_target_properties(distorm-static PROPERTIES
+            IMPORTED_LOCATION_RELEASE "$ENV{FUNCHOOK_ROOT}/lib/Release/libdistorm.a"
+            IMPORTED_LOCATION_RELWITHDEBINFO "$ENV{FUNCHOOK_ROOT}/lib/Release/libdistorm.a"
+            IMPORTED_LOCATION_MINSIZEREL "$ENV{FUNCHOOK_ROOT}/lib/Release/libdistorm.a"
+            IMPORTED_LOCATION_DEBUG "$ENV{FUNCHOOK_ROOT}/lib/Debug/libdistorm.a")
+    endif()
+else()
+    include(FetchContent)
+    set(FUNCHOOK_BUILD_TESTS OFF CACHE BOOL "" FORCE)
+    set(FUNCHOOK_BUILD_SHARED OFF CACHE BOOL "" FORCE)
+    if(DEFINED ENV{FUNCHOOK_SOURCE} AND EXISTS "$ENV{FUNCHOOK_SOURCE}/CMakeLists.txt")
+        set(FETCHCONTENT_SOURCE_DIR_FUNCHOOK "$ENV{FUNCHOOK_SOURCE}" CACHE PATH "")
+    endif()
+    FetchContent_Declare(funchook
+        GIT_REPOSITORY https://github.com/kubo/funchook.git
+        GIT_TAG v1.1.3 GIT_SHALLOW TRUE
+        UPDATE_DISCONNECTED TRUE)
+    FetchContent_MakeAvailable(funchook)
 endif()
-FetchContent_Declare(funchook
-    GIT_REPOSITORY https://github.com/kubo/funchook.git
-    GIT_TAG v1.1.3 GIT_SHALLOW TRUE
-    UPDATE_DISCONNECTED TRUE)
-FetchContent_MakeAvailable(funchook)
 
 set(SDK_SOURCES
     ${HL2SDK}/public/tier0/memoverride.cpp

--- a/README.md
+++ b/README.md
@@ -84,6 +84,8 @@ them into the package tree automatically.
 bc_lock <all|aim|jump|weapon> <slot> [slot1..slot5]
 bc_unlock <all|aim|jump|weapon> <slot>
 bc_unlock_all <all|aim|jump|weapon>
+bc_replay_pov [off|spectated|always]
+bc_perf [0|1|reset]
 bc_status
 ```
 
@@ -95,6 +97,8 @@ bc_lock jump 1               # bot 1 can no longer jump
 bc_lock all 1                # full freeze (use this before replay)
 bc_lock weapon 1 slot3       # force bot 1 to knife
 bc_unlock_all weapon         # clear every weapon lock
+bc_replay_pov spectated      # publish replay POV only for watched bots
+bc_perf 1                    # enable and print replay perf counters
 bc_status                    # print hook status + every per-slot lock
 ```
 
@@ -157,6 +161,9 @@ ABI-coupled: a native ABI bump means re-copying the file.
 using BotControllerApi;
 
 if (!BotController.IsCompatible()) return;   // requires the matching ABI
+BotController.TryGetAbiInfo(out var abiInfo);
+var capabilities = BotController.Capabilities();
+var buildId = BotController.BuildId();
 ```
 
 The static `BotController.*` calls below mirror the `IBotControllerApi` methods
@@ -191,6 +198,13 @@ BotController.StartReplay(botSlot, loop: false);
 // Or pull the buffers out, persist them, and load later
 var (ticks, subs) = BotController.GetRecordedMotion(srcSlot);
 BotController.LoadReplay(botSlot, ticks, subs);
+BotController.SetReplayPovMask(1UL << botSlot); // publish first-person POV for this replay slot
+
+// Advanced callers can load optional usercmd frames and movement extras, then
+// replay from a bounded range instead of always starting from tick 0.
+BotController.LoadReplayExtended(botSlot, ticks, subs, commands, movementExtras);
+BotController.StartReplayAt(botSlot, loop: false, startIndex: 10);
+BotController.StartReplayUntil(botSlot, loop: false, startIndex: 10, holdBeforeIndex: 200);
 
 // Drive weapon/fire from the tick being replayed
 if (BotController.TryGetReplayTick(botSlot, out var tick))

--- a/configs/addons/BotController/gamedata.json
+++ b/configs/addons/BotController/gamedata.json
@@ -93,6 +93,14 @@
     },
     "comment": "Engine eye-angle."
   },
+  "CBasePlayerPawn::GetEyeAngles": {
+    "signatures": {
+      "library": "server",
+      "windows": "48 89 5C 24 ? 57 48 81 EC ? ? ? ? 48 8B F9 48 8B DA 48 8B 89 ? ? ? ? 48 85 C9",
+      "linux": ""
+    },
+    "comment": "Eye-angle getter used by server-side camera/spectator paths."
+  },
   "CCSPlayer_MovementServices::ProcessMovement": {
     "signatures": {
       "library": "server",
@@ -100,6 +108,14 @@
       "linux": "55 48 89 E5 41 57 41 56 41 55 49 89 F5 41 54 53 48 89 FB 48 83 EC ? 48 8B 7F"
     },
     "comment": "Per-tick movement entry; 2nd arg is CMoveData."
+  },
+  "CCSPlayer_MovementServices::PhysicsSimulate": {
+    "signatures": {
+      "library": "server",
+      "windows": "40 55 53 56 57 41 54 41 56 48 8D AC 24 ? ? ? ? 48 81 EC",
+      "linux": ""
+    },
+    "comment": "Optional per-tick physics boundary; replay falls back if unavailable."
   },
   "CBasePlayerController::OnSimulateUserCommands": {
     "signatures": {
@@ -298,6 +314,20 @@
     },
     "comment": "v_angle (0xAB8)."
   },
+  "CCSPlayerPawn::ViewAnglePrevious": {
+    "offsets": {
+      "windows": 2756,
+      "linux": 3492
+    },
+    "comment": "v_anglePrevious; keeps first-person spectator/camera history aligned."
+  },
+  "CCSPlayerPawn::ServerViewAngleChanges": {
+    "offsets": {
+      "windows": 2640,
+      "linux": 3376
+    },
+    "comment": "m_ServerViewAngleChanges; used for replay-owned first-person POV updates."
+  },
   "CCSPlayerPawn::EyeAngles": {
     "offsets": {
       "windows": 4928,
@@ -346,6 +376,13 @@
       "linux": 104
     },
     "comment": "states[2] (104)."
+  },
+  "CCSPlayer_MovementServices::OldViewAngles": {
+    "offsets": {
+      "windows": 576,
+      "linux": 576
+    },
+    "comment": "m_vecOldViewAngles (0x240)."
   },
   "CCSPlayer_MovementServices::LadderNormal": {
     "offsets": {

--- a/csharp/BotControllerApi/IBotControllerApi.cs
+++ b/csharp/BotControllerApi/IBotControllerApi.cs
@@ -5,6 +5,10 @@ namespace BotControllerApi
     public interface IBotControllerApi
     {
         int AbiVersion { get; }
+        ulong Capabilities { get; }
+        string BuildId { get; }
+
+        bool TryGetAbiInfo(out AbiInfo info);
 
         // ---- locks ----
 
@@ -40,10 +44,22 @@ namespace BotControllerApi
         // Load ticks + subticks into a slot's replay buffer.
         bool LoadReplay(int slot, ReplayTick[] ticks, SubtickMove[] subs);
 
+        // Load optional usercmd frames and movement extras alongside replay ticks.
+        bool LoadReplayExtended(
+            int slot,
+            ReplayTick[] ticks,
+            SubtickMove[] subs,
+            ReplayCommandFrame[] commands,
+            ReplayMovementExtra[] movementExtras);
+
         // Move a slot's just-recorded buffers into another slot's replay buffer.
         bool TransferRecordingToReplay(int srcSlot, int dstSlot);
 
         bool StartReplay(int slot, bool loop = false);
+
+        bool StartReplayAt(int slot, bool loop, int startIndex);
+
+        bool StartReplayUntil(int slot, bool loop, int startIndex, int holdBeforeIndex);
 
         bool StopReplay(int slot);
 
@@ -55,6 +71,11 @@ namespace BotControllerApi
 
         // The tick currently being replayed on this slot, for driving weapon/fire.
         bool TryGetReplayTick(int slot, out ReplayTick tick);
+
+        bool TryGetReplaySlotState(int slot, out ReplaySlotState state);
+
+        // Bit n means replay slot n is currently watched in first-person.
+        bool SetReplayPovMask(ulong mask);
 
         // ---- weapons ----
 

--- a/csharp/BotControllerApi/Types.cs
+++ b/csharp/BotControllerApi/Types.cs
@@ -75,6 +75,77 @@ namespace BotControllerApi
         public float YawDelta;
     }
 
+    /** Optional replay usercmd frame. Must match C++ ReplayCommandFrameData */
+    [StructLayout(LayoutKind.Sequential, Pack = 4)]
+    public struct ReplayCommandFrame
+    {
+        public float ForwardMove;
+        public float LeftMove;
+        public float UpMove;
+        public float Pitch;
+        public float Yaw;
+        public float Roll;
+        public ulong Buttons;
+        public ulong Buttons1;
+        public ulong Buttons2;
+        public int MouseDx;
+        public int MouseDy;
+        public int WeaponSelect;
+        public uint Fields;
+        public byte LeftHandDesired;
+        public byte Pad0;
+        public byte Pad1;
+        public byte Pad2;
+    }
+
+    /** Optional offset-backed replay movement state. Must match C++ ReplayMovementExtra */
+    [StructLayout(LayoutKind.Sequential, Pack = 4)]
+    public struct ReplayMovementExtra
+    {
+        public uint Fields;
+        public float JumpPressedTime;
+        public float LastDuckTime;
+        public int LastActualJumpPressTick;
+        public float LastActualJumpPressFrac;
+        public int LastUsableJumpPressTick;
+        public float LastUsableJumpPressFrac;
+        public int LastLandedTick;
+        public float LastLandedFrac;
+        public float LastLandedVelocityX;
+        public float LastLandedVelocityY;
+        public float LastLandedVelocityZ;
+    }
+
+    /** Compact replay state for hot-path status checks. Must match C++ ReplaySlotState */
+    [StructLayout(LayoutKind.Sequential, Pack = 4)]
+    public struct ReplaySlotState
+    {
+        public int Playing;
+        public int Cursor;
+        public int Total;
+        public int CurrentTickIndex;
+        public int WeaponDefIndex;
+        public int NumSubtick;
+    }
+
+    /** Native ABI metadata. Must match C++ BotControllerAbiInfo */
+    [StructLayout(LayoutKind.Sequential, Pack = 4)]
+    public struct AbiInfo
+    {
+        public const int ByteSize = 44;
+
+        public int AbiMajor;
+        public int AbiMinor;
+        public int MovementSnapshotSize;
+        public int ReplayTickSize;
+        public int SubtickMoveSize;
+        public int ReplaySlotStateSize;
+        public int MaxSlots;
+        public ulong Capabilities;
+        public int Reserved0;
+        public int Reserved1;
+    }
+
     /** Bot personality / aim / weapon preference. Mirrors C++ BotProfileData */
     [StructLayout(LayoutKind.Sequential, Pack = 4)]
     public struct BotProfileData

--- a/csharp/BotControllerImpl/BotController.NativeApi.cs
+++ b/csharp/BotControllerImpl/BotController.NativeApi.cs
@@ -1,4 +1,4 @@
-// P/Invoke wrapper for BotController.dll (ABI 12). Check IsCompatible() before use.
+// P/Invoke wrapper for BotController.dll (ABI 16). Check IsCompatible() before use.
 // Main-thread only.
 //
 // Provider-internal: data types (LockKind/ReplayTick/BotProfileData/...) come
@@ -12,7 +12,16 @@ namespace BotControllerApi
     // Thin static binding over the native exports. No orchestration here.
     public static class BotController
     {
-        private const int ExpectedAbiVersion = 12;
+        private const int ExpectedAbiVersion = 16;
+        public const ulong CapabilityReplaySlotState = 1UL << 0;
+        public const ulong CapabilityStartReplayAt = 1UL << 1;
+        public const ulong CapabilityStartReplayUntil = 1UL << 2;
+        public const ulong CapabilityReplayTick = 1UL << 3;
+        public const ulong CapabilityWeaponSwitchRead = 1UL << 4;
+        public const ulong CapabilityPovMask = 1UL << 5;
+        public const ulong CapabilityBuyPlan = 1UL << 6;
+        public const ulong CapabilityControllerBotOffset = 1UL << 7;
+        public const ulong CapabilityExtendedReplay = 1UL << 8;
 
         // Sentinel weapon def meaning "any knife"
         public const int KnifeDef = 9001;
@@ -31,6 +40,18 @@ namespace BotControllerApi
 
         [DllImport("BotController", CallingConvention = CallingConvention.Cdecl)]
         private static extern int BotController_GetVersion();
+
+        [DllImport("BotController", CallingConvention = CallingConvention.Cdecl)]
+        private static extern int BotController_GetAbiInfo(out AbiInfo info, int size);
+
+        [DllImport("BotController", CallingConvention = CallingConvention.Cdecl)]
+        private static extern ulong BotController_GetCapabilities();
+
+        [DllImport("BotController", CallingConvention = CallingConvention.Cdecl)]
+        private static extern IntPtr BotController_GetBuildId();
+
+        [DllImport("BotController", CallingConvention = CallingConvention.Cdecl)]
+        private static extern int BotController_SetReplayPovMask(ulong mask);
 
         [DllImport("BotController", CallingConvention = CallingConvention.Cdecl)]
         private static extern int BotController_StartRecord(int slot);
@@ -58,10 +79,24 @@ namespace BotControllerApi
             [In] SubtickMove[] subs, int subCount);
 
         [DllImport("BotController", CallingConvention = CallingConvention.Cdecl)]
+        private static extern int BotController_LoadReplayExtended(
+            int slot, [In] ReplayTick[] ticks, int tickCount,
+            [In] SubtickMove[] subs, int subCount,
+            [In] ReplayCommandFrame[] commands, int commandCount,
+            [In] ReplayMovementExtra[] movementExtras, int movementExtraCount);
+
+        [DllImport("BotController", CallingConvention = CallingConvention.Cdecl)]
         private static extern int BotController_TransferRecordingToReplay(int srcSlot, int dstSlot);
 
         [DllImport("BotController", CallingConvention = CallingConvention.Cdecl)]
         private static extern int BotController_StartReplay(int slot, int loop);
+
+        [DllImport("BotController", CallingConvention = CallingConvention.Cdecl)]
+        private static extern int BotController_StartReplayAt(int slot, int loop, int startIndex);
+
+        [DllImport("BotController", CallingConvention = CallingConvention.Cdecl)]
+        private static extern int BotController_StartReplayUntil(
+            int slot, int loop, int startIndex, int holdBeforeIndex);
 
         [DllImport("BotController", CallingConvention = CallingConvention.Cdecl)]
         private static extern int BotController_StopReplay(int slot);
@@ -74,6 +109,9 @@ namespace BotControllerApi
 
         [DllImport("BotController", CallingConvention = CallingConvention.Cdecl)]
         private static extern int BotController_GetReplayTick(int slot, out ReplayTick tick);
+
+        [DllImport("BotController", CallingConvention = CallingConvention.Cdecl)]
+        private static extern int BotController_GetReplaySlotState(int slot, out ReplaySlotState state);
 
         [DllImport("BotController", CallingConvention = CallingConvention.Cdecl)]
         private static extern int BotController_SwitchBotWeapon(int slot, int defIndex);
@@ -105,6 +143,44 @@ namespace BotControllerApi
 
         // Native C-ABI version the loaded DLL reports.
         public static int AbiVersion => BotController_GetVersion();
+
+        public static bool TryGetAbiInfo(out AbiInfo info)
+        {
+            try
+            {
+                return BotController_GetAbiInfo(out info, AbiInfo.ByteSize) == 0;
+            }
+            catch
+            {
+                info = default;
+                return false;
+            }
+        }
+
+        public static ulong Capabilities()
+        {
+            try
+            {
+                return BotController_GetCapabilities();
+            }
+            catch
+            {
+                return 0;
+            }
+        }
+
+        public static string BuildId()
+        {
+            try
+            {
+                var buildId = Marshal.PtrToStringAnsi(BotController_GetBuildId());
+                return string.IsNullOrWhiteSpace(buildId) ? "unknown" : buildId;
+            }
+            catch
+            {
+                return "unavailable";
+            }
+        }
 
         // ---- locks ----
 
@@ -172,6 +248,24 @@ namespace BotControllerApi
                                        subs ?? Array.Empty<SubtickMove>(),
                                        subs?.Length ?? 0) == 0;
 
+        public static bool LoadReplayExtended(
+            int slot,
+            ReplayTick[] ticks,
+            SubtickMove[] subs,
+            ReplayCommandFrame[] commands,
+            ReplayMovementExtra[] movementExtras)
+            => ticks is { Length: > 0 }
+               && BotController_LoadReplayExtended(
+                   slot,
+                   ticks,
+                   ticks.Length,
+                   subs ?? Array.Empty<SubtickMove>(),
+                   subs?.Length ?? 0,
+                   commands ?? Array.Empty<ReplayCommandFrame>(),
+                   commands?.Length ?? 0,
+                   movementExtras ?? Array.Empty<ReplayMovementExtra>(),
+                   movementExtras?.Length ?? 0) == 0;
+
         // Move a slot's just-recorded buffers straight into another slot's
         // replay buffer, no managed round-trip.
         public static bool TransferRecordingToReplay(int srcSlot, int dstSlot)
@@ -179,6 +273,12 @@ namespace BotControllerApi
 
         public static bool StartReplay(int slot, bool loop = false)
             => BotController_StartReplay(slot, loop ? 1 : 0) == 0;
+
+        public static bool StartReplayAt(int slot, bool loop, int startIndex)
+            => BotController_StartReplayAt(slot, loop ? 1 : 0, startIndex) == 0;
+
+        public static bool StartReplayUntil(int slot, bool loop, int startIndex, int holdBeforeIndex)
+            => BotController_StartReplayUntil(slot, loop ? 1 : 0, startIndex, holdBeforeIndex) == 0;
 
         public static bool StopReplay(int slot) => BotController_StopReplay(slot) == 0;
 
@@ -188,10 +288,17 @@ namespace BotControllerApi
 
         public static bool IsReplaying(int slot) => BotController_GetReplayCursor(slot) >= 0;
 
+        // Bit n means replay slot n is currently watched in first-person.
+        public static bool SetReplayPovMask(ulong mask)
+            => BotController_SetReplayPovMask(mask) == 0;
+
         // The tick currently being replayed on this slot, for driving weapon/fire
         // C#-side. Returns false if the slot isn't replaying.
         public static bool TryGetReplayTick(int slot, out ReplayTick tick)
             => BotController_GetReplayTick(slot, out tick) == 0;
+
+        public static bool TryGetReplaySlotState(int slot, out ReplaySlotState state)
+            => BotController_GetReplaySlotState(slot, out state) == 0;
 
         // Switch a bot to the weapon with this def index.
         public static bool SwitchBotWeapon(int slot, int defIndex)

--- a/csharp/BotControllerImpl/BotControllerApiImpl.cs
+++ b/csharp/BotControllerImpl/BotControllerApiImpl.cs
@@ -5,6 +5,11 @@ namespace BotControllerApi
     public sealed class BotControllerApiImpl : IBotControllerApi
     {
         public int AbiVersion => BotController.AbiVersion;
+        public ulong Capabilities => BotController.Capabilities();
+        public string BuildId => BotController.BuildId();
+
+        public bool TryGetAbiInfo(out AbiInfo info)
+            => BotController.TryGetAbiInfo(out info);
 
         // ---- locks ----
         public bool Lock(int slot, LockKind kind) => BotController.Lock(slot, kind);
@@ -24,15 +29,29 @@ namespace BotControllerApi
         // ---- replay ----
         public bool LoadReplay(int slot, ReplayTick[] ticks, SubtickMove[] subs)
             => BotController.LoadReplay(slot, ticks, subs);
+        public bool LoadReplayExtended(
+            int slot,
+            ReplayTick[] ticks,
+            SubtickMove[] subs,
+            ReplayCommandFrame[] commands,
+            ReplayMovementExtra[] movementExtras)
+            => BotController.LoadReplayExtended(slot, ticks, subs, commands, movementExtras);
         public bool TransferRecordingToReplay(int srcSlot, int dstSlot)
             => BotController.TransferRecordingToReplay(srcSlot, dstSlot);
         public bool StartReplay(int slot, bool loop = false) => BotController.StartReplay(slot, loop);
+        public bool StartReplayAt(int slot, bool loop, int startIndex)
+            => BotController.StartReplayAt(slot, loop, startIndex);
+        public bool StartReplayUntil(int slot, bool loop, int startIndex, int holdBeforeIndex)
+            => BotController.StartReplayUntil(slot, loop, startIndex, holdBeforeIndex);
         public bool StopReplay(int slot) => BotController.StopReplay(slot);
         public int ReplayCursor(int slot) => BotController.ReplayCursor(slot);
         public int ReplayTotal(int slot) => BotController.ReplayTotal(slot);
         public bool IsReplaying(int slot) => BotController.IsReplaying(slot);
         public bool TryGetReplayTick(int slot, out ReplayTick tick)
             => BotController.TryGetReplayTick(slot, out tick);
+        public bool TryGetReplaySlotState(int slot, out ReplaySlotState state)
+            => BotController.TryGetReplaySlotState(slot, out state);
+        public bool SetReplayPovMask(ulong mask) => BotController.SetReplayPovMask(mask);
 
         // ---- weapons ----
         public bool SwitchBotWeapon(int slot, int defIndex)

--- a/scripts/BotController.NativeApi.cs
+++ b/scripts/BotController.NativeApi.cs
@@ -1,6 +1,7 @@
-// P/Invoke wrapper for BotController.dll (ABI 10). Check IsCompatible() before use.
+// P/Invoke wrapper for BotController.dll (ABI 16). Check IsCompatible() before use.
 // Main-thread only.
 
+using System;
 using System.Runtime.InteropServices;
 
 namespace BotControllerApi
@@ -76,29 +77,108 @@ namespace BotControllerApi
         public float YawDelta;
     }
 
+    /** Optional replay usercmd frame. Must match C++ ReplayCommandFrameData */
+    [StructLayout(LayoutKind.Sequential, Pack = 4)]
+    public struct ReplayCommandFrame
+    {
+        public float ForwardMove;
+        public float LeftMove;
+        public float UpMove;
+        public float Pitch;
+        public float Yaw;
+        public float Roll;
+        public ulong Buttons;
+        public ulong Buttons1;
+        public ulong Buttons2;
+        public int MouseDx;
+        public int MouseDy;
+        public int WeaponSelect;
+        public uint Fields;
+        public byte LeftHandDesired;
+        public byte Pad0;
+        public byte Pad1;
+        public byte Pad2;
+    }
+
+    /** Optional offset-backed replay movement state. Must match C++ ReplayMovementExtra */
+    [StructLayout(LayoutKind.Sequential, Pack = 4)]
+    public struct ReplayMovementExtra
+    {
+        public uint Fields;
+        public float JumpPressedTime;
+        public float LastDuckTime;
+        public int LastActualJumpPressTick;
+        public float LastActualJumpPressFrac;
+        public int LastUsableJumpPressTick;
+        public float LastUsableJumpPressFrac;
+        public int LastLandedTick;
+        public float LastLandedFrac;
+        public float LastLandedVelocityX;
+        public float LastLandedVelocityY;
+        public float LastLandedVelocityZ;
+    }
+
+    [StructLayout(LayoutKind.Sequential, Pack = 4)]
+    public struct AbiInfo
+    {
+        public const int ByteSize = 44;
+
+        public int AbiMajor;
+        public int AbiMinor;
+        public int MovementSnapshotSize;
+        public int ReplayTickSize;
+        public int SubtickMoveSize;
+        public int ReplaySlotStateSize;
+        public int MaxSlots;
+        public ulong Capabilities;
+        public int Reserved0;
+        public int Reserved1;
+    }
+
+    /** Compact replay state for hot-path status checks. Must match C++ ReplaySlotState */
+    [StructLayout(LayoutKind.Sequential, Pack = 4)]
+    public struct ReplaySlotState
+    {
+        public int Playing;
+        public int Cursor;
+        public int Total;
+        public int CurrentTickIndex;
+        public int WeaponDefIndex;
+        public int NumSubtick;
+    }
+
     /** Bot personality / aim / weapon preference. Mirrors C++ BotProfileData */
     [StructLayout(LayoutKind.Sequential, Pack = 4)]
     public struct BotProfileData
     {
-        public float Aggression;    // 0..1
-        public float Skill;         // 0..1
-        public float Teamwork;      // 0..1
-        public float ReactionTime;  // seconds
-        public float AttackDelay;   // seconds
-        public float LookAccelAtk;  // m_lookAngleMaxAccelAttacking
-        public float LookStiffAtk;  // m_lookAngleStiffnessAttacking
-        public float LookDampAtk;   // m_lookAngleDampingAttacking
+        public float Aggression;
+        public float Skill;
+        public float Teamwork;
+        public float ReactionTime;
+        public float AttackDelay;
+        public float LookAccelAtk;
+        public float LookStiffAtk;
+        public float LookDampAtk;
         public int Cost;
-        public int Difficulty;      // bitmask EASY/NORMAL/HARD/EXPERT
+        public int Difficulty;
         public int WeaponPrefCount;
         [MarshalAs(UnmanagedType.ByValArray, SizeConst = 16)]
-        public ushort[] WeaponPref; // item def index, [0..WeaponPrefCount)
+        public ushort[] WeaponPref;
     }
 
     // Thin static binding over the native exports. No orchestration here.
     public static class BotController
     {
-        private const int ExpectedAbiVersion = 12;
+        public const int ExpectedAbiVersion = 16;
+        public const ulong CapabilityReplaySlotState = 1UL << 0;
+        public const ulong CapabilityStartReplayAt = 1UL << 1;
+        public const ulong CapabilityStartReplayUntil = 1UL << 2;
+        public const ulong CapabilityReplayTick = 1UL << 3;
+        public const ulong CapabilityWeaponSwitchRead = 1UL << 4;
+        public const ulong CapabilityPovMask = 1UL << 5;
+        public const ulong CapabilityBuyPlan = 1UL << 6;
+        public const ulong CapabilityControllerBotOffset = 1UL << 7;
+        public const ulong CapabilityExtendedReplay = 1UL << 8;
 
         // Sentinel weapon def meaning "any knife"
         public const int KnifeDef = 9001;
@@ -117,6 +197,21 @@ namespace BotControllerApi
 
         [DllImport("BotController", CallingConvention = CallingConvention.Cdecl)]
         private static extern int BotController_GetVersion();
+
+        [DllImport("BotController", CallingConvention = CallingConvention.Cdecl)]
+        private static extern int BotController_GetAbiInfo(out AbiInfo info, int size);
+
+        [DllImport("BotController", CallingConvention = CallingConvention.Cdecl)]
+        private static extern ulong BotController_GetCapabilities();
+
+        [DllImport("BotController", CallingConvention = CallingConvention.Cdecl)]
+        private static extern IntPtr BotController_GetBuildId();
+
+        [DllImport("BotController", CallingConvention = CallingConvention.Cdecl)]
+        private static extern int BotController_SetReplayPovMask(ulong mask);
+
+        [DllImport("BotController", CallingConvention = CallingConvention.Cdecl)]
+        private static extern int BotController_SetControllerControllingBotOffset(int offset);
 
         [DllImport("BotController", CallingConvention = CallingConvention.Cdecl)]
         private static extern int BotController_StartRecord(int slot);
@@ -144,10 +239,24 @@ namespace BotControllerApi
             [In] SubtickMove[] subs, int subCount);
 
         [DllImport("BotController", CallingConvention = CallingConvention.Cdecl)]
+        private static extern int BotController_LoadReplayExtended(
+            int slot, [In] ReplayTick[] ticks, int tickCount,
+            [In] SubtickMove[] subs, int subCount,
+            [In] ReplayCommandFrame[] commands, int commandCount,
+            [In] ReplayMovementExtra[] movementExtras, int movementExtraCount);
+
+        [DllImport("BotController", CallingConvention = CallingConvention.Cdecl)]
         private static extern int BotController_TransferRecordingToReplay(int srcSlot, int dstSlot);
 
         [DllImport("BotController", CallingConvention = CallingConvention.Cdecl)]
         private static extern int BotController_StartReplay(int slot, int loop);
+
+        [DllImport("BotController", CallingConvention = CallingConvention.Cdecl)]
+        private static extern int BotController_StartReplayAt(int slot, int loop, int startIndex);
+
+        [DllImport("BotController", CallingConvention = CallingConvention.Cdecl)]
+        private static extern int BotController_StartReplayUntil(
+            int slot, int loop, int startIndex, int holdBeforeIndex);
 
         [DllImport("BotController", CallingConvention = CallingConvention.Cdecl)]
         private static extern int BotController_StopReplay(int slot);
@@ -160,6 +269,9 @@ namespace BotControllerApi
 
         [DllImport("BotController", CallingConvention = CallingConvention.Cdecl)]
         private static extern int BotController_GetReplayTick(int slot, out ReplayTick tick);
+
+        [DllImport("BotController", CallingConvention = CallingConvention.Cdecl)]
+        private static extern int BotController_GetReplaySlotState(int slot, out ReplaySlotState state);
 
         [DllImport("BotController", CallingConvention = CallingConvention.Cdecl)]
         private static extern int BotController_SwitchBotWeapon(int slot, int defIndex);
@@ -188,6 +300,49 @@ namespace BotControllerApi
 
         // Native ABI must match what this wrapper expects.
         public static bool IsCompatible() => BotController_GetVersion() == ExpectedAbiVersion;
+
+        public static int AbiVersion() => BotController_GetVersion();
+
+        public static bool TryGetAbiInfo(out AbiInfo info)
+        {
+            try
+            {
+                return BotController_GetAbiInfo(out info, AbiInfo.ByteSize) == 0;
+            }
+            catch
+            {
+                info = default;
+                return false;
+            }
+        }
+
+        public static ulong Capabilities()
+        {
+            try
+            {
+                return BotController_GetCapabilities();
+            }
+            catch
+            {
+                return 0;
+            }
+        }
+
+        public static string BuildId()
+        {
+            try
+            {
+                var buildId = Marshal.PtrToStringAnsi(BotController_GetBuildId());
+                return string.IsNullOrWhiteSpace(buildId) ? "unknown" : buildId;
+            }
+            catch
+            {
+                return "unavailable";
+            }
+        }
+
+        public static bool SetControllerControllingBotOffset(int offset)
+            => BotController_SetControllerControllingBotOffset(offset) == 0;
 
         // ---- locks ----
 
@@ -255,6 +410,24 @@ namespace BotControllerApi
                                        subs ?? Array.Empty<SubtickMove>(),
                                        subs?.Length ?? 0) == 0;
 
+        public static bool LoadReplayExtended(
+            int slot,
+            ReplayTick[] ticks,
+            SubtickMove[] subs,
+            ReplayCommandFrame[] commands,
+            ReplayMovementExtra[] movementExtras)
+            => ticks is { Length: > 0 }
+               && BotController_LoadReplayExtended(
+                   slot,
+                   ticks,
+                   ticks.Length,
+                   subs ?? Array.Empty<SubtickMove>(),
+                   subs?.Length ?? 0,
+                   commands ?? Array.Empty<ReplayCommandFrame>(),
+                   commands?.Length ?? 0,
+                   movementExtras ?? Array.Empty<ReplayMovementExtra>(),
+                   movementExtras?.Length ?? 0) == 0;
+
         // Move a slot's just-recorded buffers straight into another slot's
         // replay buffer, no managed round-trip.
         public static bool TransferRecordingToReplay(int srcSlot, int dstSlot)
@@ -262,6 +435,12 @@ namespace BotControllerApi
 
         public static bool StartReplay(int slot, bool loop = false)
             => BotController_StartReplay(slot, loop ? 1 : 0) == 0;
+
+        public static bool StartReplayAt(int slot, bool loop, int startIndex)
+            => BotController_StartReplayAt(slot, loop ? 1 : 0, startIndex) == 0;
+
+        public static bool StartReplayUntil(int slot, bool loop, int startIndex, int holdBeforeIndex)
+            => BotController_StartReplayUntil(slot, loop ? 1 : 0, startIndex, holdBeforeIndex) == 0;
 
         public static bool StopReplay(int slot) => BotController_StopReplay(slot) == 0;
 
@@ -271,10 +450,17 @@ namespace BotControllerApi
 
         public static bool IsReplaying(int slot) => BotController_GetReplayCursor(slot) >= 0;
 
+        // Bit n means replay slot n is currently watched in first-person.
+        public static bool SetReplayPovMask(ulong mask)
+            => BotController_SetReplayPovMask(mask) == 0;
+
         // The tick currently being replayed on this slot, for driving weapon/fire
         // C#-side. Returns false if the slot isn't replaying.
         public static bool TryGetReplayTick(int slot, out ReplayTick tick)
             => BotController_GetReplayTick(slot, out tick) == 0;
+
+        public static bool TryGetReplaySlotState(int slot, out ReplaySlotState state)
+            => BotController_GetReplaySlotState(slot, out state) == 0;
 
         // Switch a bot to the weapon with this def index.
         public static bool SwitchBotWeapon(int slot, int defIndex)
@@ -285,10 +471,8 @@ namespace BotControllerApi
         public static int BotActiveWeaponDef(int slot)
             => BotController_GetBotActiveWeaponDef(slot);
 
-        // ---- profile ----
-
         // Read the BotProfile of the bot on this slot. Returns false if the slot
-        // has no live bot (it must have ticked at least once) or null profile.
+        // has no live bot or null profile.
         public static bool TryGetProfile(int slot, out BotProfileData profile)
             => BotController_GetProfile(slot, out profile) == 0;
 

--- a/src/BotController/BotController.cpp
+++ b/src/BotController/BotController.cpp
@@ -24,6 +24,7 @@ using Upkeep_t = void(BC_FASTCALL *)(void *bot);
 using Jump_t = char(BC_FASTCALL *)(void *bot, char mustJump);
 using UpdateLookAngles_t = void(BC_FASTCALL *)(void *bot);
 using SetEyeAngles_t = void(BC_FASTCALL *)(void *pawn, float *angle);
+using GetEyeAngles_t = float *(BC_FASTCALL *)(void *pawn, float *out);
 
 namespace BotController
 {
@@ -39,6 +40,9 @@ namespace BotController
         static void *g_addrUpdateLookAngles = nullptr;
         static SetEyeAngles_t g_origSetEyeAngles = nullptr;
         static void *g_addrSetEyeAngles = nullptr;
+        static GetEyeAngles_t g_origGetEyeAngles = nullptr;
+        static void *g_addrGetEyeAngles = nullptr;
+        static thread_local bool g_replayOwnedSetEyeAngles = false;
         static bool g_installed = false;
         static std::string g_status = "not_attempted";
 
@@ -51,6 +55,15 @@ namespace BotController
         static Hook g_hookJump;
         static Hook g_hookUpdateLookAngles;
         static Hook g_hookSetEyeAngles;
+        static Hook g_hookGetEyeAngles;
+
+        static float NormalizeDeg(float a)
+        {
+            a = std::fmod(a + 180.0f, 360.0f);
+            if (a < 0.0f)
+                a += 360.0f;
+            return a - 180.0f;
+        }
 
         // Skip the Bot tick under All lock OR while replaying
         static void BC_FASTCALL HookedUpdate(void *bot)
@@ -70,19 +83,14 @@ namespace BotController
             g_origUpdate(bot);
         }
 
-        // Skip the per-frame view tick under All or Aim lock.
-        // EXCEPTION: while a slot is replaying, drive ONLY the view
+        // Skip the per-frame view tick under replay, All, or Aim lock.
         static void BC_FASTCALL HookedUpdateLookAngles(void *bot); // fwd decl
 
         static void BC_FASTCALL HookedUpkeep(void *bot)
         {
             int slot = CCSBotToSlot(bot);
             if (slot >= 0 && MotionRecorder::IsReplaying(slot))
-            {
-                if (g_origUpdateLookAngles)
-                    HookedUpdateLookAngles(bot); // view only, no locomotion
                 return;
-            }
             if (slot >= 0 &&
                 (BotControllerState::GetAll(slot) || BotControllerState::GetAim(slot)))
             {
@@ -91,9 +99,16 @@ namespace BotController
             g_origUpkeep(bot);
         }
 
-        // view replay
         static void BC_FASTCALL HookedUpdateLookAngles(void *bot)
         {
+            int slot = CCSBotToSlot(bot);
+            if (slot >= 0 &&
+                (MotionRecorder::IsReplaying(slot) ||
+                 BotControllerState::GetAll(slot) ||
+                 BotControllerState::GetAim(slot)))
+            {
+                return;
+            }
             g_origUpdateLookAngles(bot);
         }
 
@@ -101,14 +116,44 @@ namespace BotController
         static void BC_FASTCALL HookedSetEyeAngles(void *pawn, float *angle)
         {
             int slot = pawn ? ControllerSlotForPawn(pawn) : -1;
-            ReplayTick t{};
-            if (slot >= 0 && MotionRecorder::CurrentReplayTick(slot, t))
+            if (slot >= 0 && MotionRecorder::IsReplaying(slot) && !g_replayOwnedSetEyeAngles &&
+                !MotionRecorder::ReplayViewAllowsEngineSetEyeAngles())
             {
-                float a[3] = {t.post.pitch, t.post.yaw, 0.0f};
-                g_origSetEyeAngles(pawn, a);
                 return;
             }
             g_origSetEyeAngles(pawn, angle);
+        }
+
+        bool ApplyReplayEyeAngles(void *pawn, float pitch, float yaw)
+        {
+            if (!pawn || !g_origSetEyeAngles)
+                return false;
+
+            float angle[3] = {pitch, NormalizeDeg(yaw), 0.0f};
+            bool oldGuard = g_replayOwnedSetEyeAngles;
+            g_replayOwnedSetEyeAngles = true;
+            g_origSetEyeAngles(pawn, angle);
+            g_replayOwnedSetEyeAngles = oldGuard;
+            return true;
+        }
+
+        static float *BC_FASTCALL HookedGetEyeAngles(void *pawn, float *out)
+        {
+            int slot = pawn ? ControllerSlotForPawn(pawn) : -1;
+
+            if (slot >= 0 && out && MotionRecorder::IsReplaying(slot))
+            {
+                MovementSnapshot view{};
+                if (MotionRecorder::ReplaySpectatorView(slot, view))
+                {
+                    out[0] = view.pitch;
+                    out[1] = NormalizeDeg(view.yaw);
+                    out[2] = 0.0f;
+                    return out;
+                }
+            }
+
+            return g_origGetEyeAngles ? g_origGetEyeAngles(pawn, out) : out;
         }
 
         // Skip Jump under Jump lock; return 0 mimics its own gate-fail.
@@ -179,6 +224,22 @@ namespace BotController
                 std::snprintf(dbg, sizeof(dbg),
                               "[BotController] WARN: CCSPlayerPawn::SetEyeAngles sig not resolved (%s); replay 1:1 view disabled\n",
                               seaErr);
+                DebugOut(dbg);
+            }
+
+            // GetEyeAngles is optional; replay can still drive server state
+            // without it, but first-person spectator camera may read through
+            // this getter instead of raw pawn fields.
+            char geaErr[256] = {0};
+            g_addrGetEyeAngles = Sig::ResolveSig(gd, serverModule,
+                                                 "CBasePlayerPawn::GetEyeAngles",
+                                                 geaErr, sizeof(geaErr));
+            if (!g_addrGetEyeAngles)
+            {
+                char dbg[320];
+                std::snprintf(dbg, sizeof(dbg),
+                              "[BotController] WARN: CBasePlayerPawn::GetEyeAngles sig not resolved (%s); replay spectator view override disabled\n",
+                              geaErr);
                 DebugOut(dbg);
             }
 
@@ -255,14 +316,30 @@ namespace BotController
                 }
             }
 
+            // optional: GetEyeAngles
+            if (g_addrGetEyeAngles)
+            {
+                if (!g_hookGetEyeAngles.Create(g_addrGetEyeAngles,
+                                               reinterpret_cast<void *>(&HookedGetEyeAngles),
+                                               reinterpret_cast<void **>(&g_origGetEyeAngles)) ||
+                    !g_hookGetEyeAngles.Enable())
+                {
+                    DebugOut("[BotController] WARN: hook GetEyeAngles failed; replay spectator view override disabled\n");
+                    g_hookGetEyeAngles.Remove();
+                    g_origGetEyeAngles = nullptr;
+                    g_addrGetEyeAngles = nullptr;
+                }
+            }
+
             g_installed = true;
             g_status = "ok";
 
             char dbg[400];
             std::snprintf(dbg, sizeof(dbg),
-                          "[BotController] Update@%p Upkeep@%p Jump@%p ULA@%p SEA@%p\n",
+                          "[BotController] Update@%p Upkeep@%p Jump@%p ULA@%p SEA@%p GEA@%p\n",
                           g_addrUpdate, g_addrUpkeep, g_addrJump,
-                          g_addrUpdateLookAngles, g_addrSetEyeAngles);
+                          g_addrUpdateLookAngles, g_addrSetEyeAngles,
+                          g_addrGetEyeAngles);
             DebugOut(dbg);
             return true;
         }
@@ -271,6 +348,8 @@ namespace BotController
         {
             if (!g_installed)
                 return;
+            g_hookGetEyeAngles.Remove();
+            g_origGetEyeAngles = nullptr;
             g_hookSetEyeAngles.Remove();
             g_origSetEyeAngles = nullptr;
             g_hookUpdateLookAngles.Remove();
@@ -295,8 +374,9 @@ namespace BotController
         void *UpkeepAddress() { return g_addrUpkeep; }
         void *JumpAddress() { return g_addrJump; }
         void *UpdateLookAnglesAddress() { return g_addrUpdateLookAngles; }
+        void *SetEyeAnglesAddress() { return g_addrSetEyeAngles; }
+        void *GetEyeAnglesAddress() { return g_addrGetEyeAngles; }
 
-        // Last CCSBot* seen in Update for this slot
         void *BotForSlot(int slot)
         {
             if (slot < 0 || slot >= 64)

--- a/src/BotController/BotController.h
+++ b/src/BotController/BotController.h
@@ -20,10 +20,16 @@ namespace BotController
 
         const char *Status();
 
+        // Apply replay-owned eye angles through the native engine path so
+        // derived third-person/body orientation state stays synchronized.
+        bool ApplyReplayEyeAngles(void *pawn, float pitch, float yaw);
+
         void *UpdateAddress();
         void *UpkeepAddress();
         void *JumpAddress();
         void *UpdateLookAnglesAddress();
+        void *SetEyeAnglesAddress();
+        void *GetEyeAnglesAddress();
 
         // Last CCSBot* seen in Update for this slot, or nullptr. Used to read
         // the bot's BotProfile by slot.

--- a/src/BotRecorder/InputInjector.cpp
+++ b/src/BotRecorder/InputInjector.cpp
@@ -9,6 +9,7 @@
 #include "ccsbot_slot.h"
 #include "sig_scan.h"
 #include "MotionRecorder.h"
+#include "WeaponLocker.h"
 #include "version_targets.h"
 #include "hook.h"
 #include "platform.h"
@@ -54,63 +55,84 @@ namespace BotController
 
         // slot -> live CCSPlayer_MovementServices*
         static std::array<std::atomic<void *>, kMaxSlots> g_slotServices{};
+        static std::array<std::atomic<bool>, kMaxSlots> g_slotControllingBot{};
+        // -1 = none, 0 = right hand desired, 1 = left hand desired.
+        static std::array<std::atomic<int>, kMaxSlots> g_replayHandednessOverride{};
+        struct ReplayHandednessOverrideInit
+        {
+            ReplayHandednessOverrideInit()
+            {
+                for (auto &entry : g_replayHandednessOverride)
+                    entry.store(-1, std::memory_order_relaxed);
+            }
+        };
+        static ReplayHandednessOverrideInit g_replayHandednessOverrideInit;
+        static std::atomic<int> g_controllerControllingBotOffset{-1};
 
         static std::atomic<uint64_t> g_hookCalls{0};
         static std::atomic<int> g_lastSlot{-1};
-        static std::atomic<uint64_t> g_finishMoveCalls{0};
-        static std::atomic<uint64_t> g_playerRunCommandCalls{0};
-        static std::atomic<uint64_t> g_physicsSimulateCalls{0};
-        static std::atomic<int> g_lastPhysicsSlot{-1};
-        static std::atomic<uint64_t> g_replayCommitCalls{0};
-        static std::atomic<uint64_t> g_slotResolveCalls{0};
-        static std::atomic<uint64_t> g_slotResolveFailures{0};
-        static std::atomic<uintptr_t> g_lastServices{0};
-        static std::atomic<uintptr_t> g_lastPawn{0};
-        static std::atomic<uint32_t> g_lastControllerHandle{0};
-        static std::atomic<uint32_t> g_lastOriginalControllerHandle{0};
-        static std::atomic<int> g_lastControllerIndex{-1};
-        static std::atomic<int> g_lastOriginalControllerIndex{-1};
-        static std::atomic<int> g_lastOwnerSlot{-1};
+        static std::atomic<bool> g_replaySubtickViewDeltas{false};
 
-        static bool IsThrowableUtilityDef(int def)
+        void SetReplaySubtickViewDeltas(bool enabled)
         {
-            return def >= 43 && def <= 48;
+            g_replaySubtickViewDeltas.store(enabled, std::memory_order_relaxed);
         }
 
+        bool ReplaySubtickViewDeltas()
+        {
+            return g_replaySubtickViewDeltas.load(std::memory_order_relaxed);
+        }
+
+        void SetReplayHandednessOverride(int slot, bool leftHandDesired)
+        {
+            if (slot >= 0 && slot < kMaxSlots)
+                g_replayHandednessOverride[slot].store(
+                    leftHandDesired ? 1 : 0,
+                    std::memory_order_release);
+        }
+
+        void ClearReplayHandednessOverride(int slot)
+        {
+            if (slot >= 0 && slot < kMaxSlots)
+                g_replayHandednessOverride[slot].store(-1, std::memory_order_release);
+        }
+
+        void ClearReplayHandednessOverrides()
+        {
+            for (auto &entry : g_replayHandednessOverride)
+                entry.store(-1, std::memory_order_release);
+        }
+
+        static int ReplayHandednessOverride(int slot)
+        {
+            return slot >= 0 && slot < kMaxSlots
+                       ? g_replayHandednessOverride[slot].load(std::memory_order_acquire)
+                       : -1;
+        }
+
+        static bool SlotIsControllingBot(int slot)
+        {
+            return slot >= 0 && slot < kMaxSlots &&
+                   g_slotControllingBot[slot].load(std::memory_order_acquire);
+        }
+
+        void *LiveMovementServices(int slot)
+        {
+            return slot >= 0 && slot < kMaxSlots
+                       ? g_slotServices[slot].load(std::memory_order_acquire)
+                       : nullptr;
+        }
+
+        // services -> player slot via pawn ptr at services+56, then m_hController.
         static int ServicesToSlot(void *services)
         {
-            g_slotResolveCalls.fetch_add(1, std::memory_order_relaxed);
-            g_lastServices.store(reinterpret_cast<uintptr_t>(services), std::memory_order_relaxed);
-            g_lastPawn.store(0, std::memory_order_relaxed);
-            g_lastControllerHandle.store(0, std::memory_order_relaxed);
-            g_lastOriginalControllerHandle.store(0, std::memory_order_relaxed);
-            g_lastControllerIndex.store(-1, std::memory_order_relaxed);
-            g_lastOriginalControllerIndex.store(-1, std::memory_order_relaxed);
-            g_lastOwnerSlot.store(-1, std::memory_order_relaxed);
-
             if (!services)
-            {
-                g_slotResolveFailures.fetch_add(1, std::memory_order_relaxed);
                 return -1;
-            }
             void *pawn = *reinterpret_cast<void **>(
                 reinterpret_cast<char *>(services) + tg::kServices_Pawn);
             if (!pawn)
-            {
-                g_slotResolveFailures.fetch_add(1, std::memory_order_relaxed);
                 return -1;
-            }
-
-            PawnControllerHandles handles = ReadPawnControllerHandles(pawn);
-            g_lastPawn.store(reinterpret_cast<uintptr_t>(pawn), std::memory_order_relaxed);
-            g_lastControllerHandle.store(handles.controllerHandle, std::memory_order_relaxed);
-            g_lastOriginalControllerHandle.store(handles.originalControllerHandle, std::memory_order_relaxed);
-            g_lastControllerIndex.store(handles.controllerIndex, std::memory_order_relaxed);
-            g_lastOriginalControllerIndex.store(handles.originalControllerIndex, std::memory_order_relaxed);
-            g_lastOwnerSlot.store(handles.ownerSlot, std::memory_order_relaxed);
-            if (handles.ownerSlot < 0)
-                g_slotResolveFailures.fetch_add(1, std::memory_order_relaxed);
-            return handles.ownerSlot;
+            return ControllerSlotForPawn(pawn);
         }
 
         // services -> pawn -> WeaponServices*, for the recording weapon tap.
@@ -126,12 +148,53 @@ namespace BotController
                 reinterpret_cast<char *>(pawn) + tg::kPawn_WeaponServices);
         }
 
+        static bool SlotIsKnownBotCommandSource(int slot, void *services)
+        {
+            if (slot < 0 || slot >= kMaxSlots || !services)
+                return false;
+            void *currentWs = ServicesToWeaponServices(services);
+            return currentWs && currentWs == WeaponLockerHooks::WsForSlot(slot);
+        }
+
         static float NormalizeDeg(float a)
         {
             a = std::fmod(a + 180.0f, 360.0f);
             if (a < 0.0f)
                 a += 360.0f;
             return a - 180.0f;
+        }
+
+        bool SetControllerControllingBotOffset(int offset)
+        {
+            if (offset < 0 || offset > 0x10000)
+                offset = -1;
+            g_controllerControllingBotOffset.store(offset, std::memory_order_release);
+            return true;
+        }
+
+        static bool ControllerIsControllingBot(void *controller)
+        {
+            int offset = g_controllerControllingBotOffset.load(std::memory_order_acquire);
+            if (!controller || offset < 0)
+                return false;
+            return *reinterpret_cast<uint8_t *>(reinterpret_cast<char *>(controller) + offset) != 0;
+        }
+
+        static bool ReplayActiveAndSafe(int slot)
+        {
+            if (slot < 0 || slot >= kMaxSlots || !MotionRecorder::IsReplaying(slot))
+                return false;
+            if (!g_slotControllingBot[slot].load(std::memory_order_acquire))
+                return true;
+
+            ClearReplayHandednessOverride(slot);
+            MotionRecorder::StopReplay(slot);
+            char dbg[128];
+            std::snprintf(dbg, sizeof(dbg),
+                          "[BotController] stopped replay slot=%d: controller is controlling a bot\n",
+                          slot);
+            DebugOut(dbg);
+            return false;
         }
 
         // ---- ProcessMovement: record pre/post + replay pre ----
@@ -141,6 +204,7 @@ namespace BotController
 
         static void BC_FASTCALL HookedProcessMovement(void *services, void *moveData)
         {
+            MotionRecorder::AddReplayPerf(MotionRecorder::ReplayPerfCounter::ProcessMovementHook);
             g_hookCalls.fetch_add(1, std::memory_order_relaxed);
             int slot = ServicesToSlot(services);
             g_lastSlot.store(slot, std::memory_order_relaxed);
@@ -154,8 +218,7 @@ namespace BotController
 
             bool recording = slot >= 0 && slot < kMaxSlots &&
                              MotionRecorder::IsRecording(slot);
-            bool replaying = slot >= 0 && slot < kMaxSlots &&
-                             MotionRecorder::IsReplaying(slot);
+            bool replaying = ReplayActiveAndSafe(slot);
 
             // Recording weapon tap
             if (recording)
@@ -181,41 +244,43 @@ namespace BotController
         static void BC_FASTCALL HookedFinishMove(void *services, void *cmd,
                                                 void *moveData)
         {
-            g_finishMoveCalls.fetch_add(1, std::memory_order_relaxed);
+            MotionRecorder::AddReplayPerf(MotionRecorder::ReplayPerfCounter::FinishMoveHook);
             int slot = ServicesToSlot(services);
-            bool replaying = slot >= 0 && slot < kMaxSlots &&
-                             MotionRecorder::IsReplaying(slot);
+            bool replaying = ReplayActiveAndSafe(slot);
 
-            // Before original: write post snapshot into MoveData.
+            // Before original: write post snapshot into MoveData + force resync.
             if (replaying)
                 MotionRecorder::OnReplayFinishMove(slot, services, moveData);
 
             g_origFinishMove(services, cmd, moveData);
 
+            // After original: publish post view while the current replay cursor
+            // still points at this simulation tick.
+            if (replaying)
+                MotionRecorder::OnReplayFinalView(slot, services);
+
             // After original: commit moveType/flags + advance the replay cursor
             if (replaying && !g_physicsActive)
-            {
                 MotionRecorder::OnReplayCommit(slot, services);
-                g_replayCommitCalls.fetch_add(1, std::memory_order_relaxed);
-            }
         }
 
         // ---- PlayerRunCommand: subtick record + re-inject ----
 
         static void BC_FASTCALL HookedPlayerRunCommand(void *services, void *cmd)
         {
-            g_playerRunCommandCalls.fetch_add(1, std::memory_order_relaxed);
+            MotionRecorder::AddReplayPerf(MotionRecorder::ReplayPerfCounter::PlayerRunCommandHook);
             int slot = ServicesToSlot(services);
             bool recording = slot >= 0 && slot < kMaxSlots &&
                              MotionRecorder::IsRecording(slot);
-            bool replaying = slot >= 0 && slot < kMaxSlots &&
-                             MotionRecorder::IsReplaying(slot);
+            bool replaying = ReplayActiveAndSafe(slot);
+            const int handednessOverride = ReplayHandednessOverride(slot);
 
-            if (cmd && (recording || replaying))
+            if (cmd && (recording || replaying || handednessOverride >= 0))
             {
                 // Compiler computes the multiple-inheritance adjust here.
                 auto *pc = reinterpret_cast<PlayerCommand *>(cmd);
                 CBaseUserCmdPB *base = pc->mutable_base();
+                bool wroteHandedness = false;
 
                 if (recording)
                 {
@@ -241,102 +306,97 @@ namespace BotController
 
                 if (replaying)
                 {
-                    const uint64_t kInAttack = 1ull; // IN_ATTACK bit0
-                    uint64_t b0 = 0, b1 = 0, b2 = 0;
-                    bool haveButtons = MotionRecorder::CurrentReplayInputButtons(slot, b0, b1, b2);
-
-                    MovementSnapshot cmdView{};
-                    if (MotionRecorder::ReplayCommandViewSnapshot(slot, cmdView))
+                    MotionRecorder::ReplayCommandFrame frame{};
+                    if (MotionRecorder::ReplayCommandFrameForSimulation(slot, frame))
                     {
-                        CMsgQAngle *view = base->mutable_viewangles();
-                        view->set_x(cmdView.pitch);
-                        view->set_y(NormalizeDeg(cmdView.yaw));
-                        view->set_z(0.0f);
-                    }
-
-                    int recordedDef = MotionRecorder::CurrentReplayWeaponDef(slot);
-                    int wsel = MotionRecorder::CurrentReplayWeaponSelect(slot);
-                    if (wsel >= 0)
-                        base->set_weaponselect(wsel);
-
-                    bool suppressUnsafeUtilityAttack =
-                        IsThrowableUtilityDef(recordedDef) &&
-                        wsel < 0 &&
-                        MotionRecorder::BotActiveWeaponDef(slot) != recordedDef;
-
-                    if (haveButtons)
-                    {
-                        if (suppressUnsafeUtilityAttack)
-                        {
-                            b0 &= ~kInAttack;
-                            b1 &= ~kInAttack;
-                            b2 &= ~kInAttack;
-                        }
-
                         CInButtonStatePB *bp = base->mutable_buttons_pb();
-                        bp->set_buttonstate1(b0);
-                        bp->set_buttonstate2(b1);
-                        bp->set_buttonstate3(b2);
-                        pc->buttonstates.m_pButtonStates[0] = b0;
-                        pc->buttonstates.m_pButtonStates[1] = b1;
-                        pc->buttonstates.m_pButtonStates[2] = b2;
-                    }
+                        bp->set_buttonstate1(frame.buttons0);
+                        bp->set_buttonstate2(frame.buttons1);
+                        bp->set_buttonstate3(frame.buttons2);
+                        pc->buttonstates.m_pButtonStates[0] = frame.buttons0;
+                        pc->buttonstates.m_pButtonStates[1] = frame.buttons1;
+                        pc->buttonstates.m_pButtonStates[2] = frame.buttons2;
 
-                    // Replace the command's subtick_moves with the recorded set for this tick
-                    SubtickMove out[MotionRecorder::kMaxSubtickPerTick];
-                    int n = MotionRecorder::CurrentReplaySubticks(
-                        slot, out, MotionRecorder::kMaxSubtickPerTick);
-                    base->clear_subtick_moves();
-                    /* ? Throw-window diagnostic */
-                    int dbgStBtn = -1;
-                    float dbgStPressed = -1.0f, dbgStWhen = -1.0f;
-                    for (int i = 0; i < n; ++i)
-                    {
-                        uint32_t button = out[i].button;
-                        float pressed = out[i].pressed;
-                        if (suppressUnsafeUtilityAttack && (button & kInAttack))
+                        CMsgQAngle *view = base->mutable_viewangles();
+                        view->set_x(frame.commandView.pitch);
+                        view->set_y(NormalizeDeg(frame.commandView.yaw));
+                        view->set_z(
+                            (frame.commandFields & MotionRecorder::kCommandFieldViewAngles) != 0
+                                ? frame.commandView.roll
+                                : 0.0f);
+
+                        if ((frame.commandFields & MotionRecorder::kCommandFieldForwardMove) != 0)
+                            base->set_forwardmove(frame.forwardMove);
+                        if ((frame.commandFields & MotionRecorder::kCommandFieldLeftMove) != 0)
+                            base->set_leftmove(frame.leftMove);
+                        if ((frame.commandFields & MotionRecorder::kCommandFieldUpMove) != 0)
+                            base->set_upmove(frame.upMove);
+                        if ((frame.commandFields & MotionRecorder::kCommandFieldMouse) != 0)
                         {
-                            button &= ~static_cast<uint32_t>(kInAttack);
-                            if (button == 0)
-                                pressed = 0.0f;
+                            base->set_mousedx(frame.mouseDx);
+                            base->set_mousedy(frame.mouseDy);
+                        }
+                        if ((frame.commandFields & MotionRecorder::kCommandFieldLeftHand) != 0)
+                        {
+                            const bool leftHandDesired = frame.leftHandDesired != 0;
+                            pc->set_left_hand_desired(leftHandDesired);
+                            SetReplayHandednessOverride(slot, leftHandDesired);
+                            wroteHandedness = true;
                         }
 
-                        CSubtickMoveStep *m = base->add_subtick_moves();
-                        m->set_when(out[i].when);
-                        m->set_button(button);
-                        if (button != 0) // digital press/release
-                            m->set_pressed(pressed != 0.0f);
-                        if (out[i].pitchDelta != 0.0f)
-                            m->set_pitch_delta(out[i].pitchDelta);
-                        if (out[i].yawDelta != 0.0f)
-                            m->set_yaw_delta(out[i].yawDelta);
-                        if (out[i].analogForward != 0.0f)
-                            m->set_analog_forward_delta(out[i].analogForward);
-                        if (out[i].analogLeft != 0.0f)
-                            m->set_analog_left_delta(out[i].analogLeft);
-                        if (button & kInAttack) // IN_ATTACK subtick
-                        {
-                            dbgStBtn = static_cast<int>(button);
-                            dbgStPressed = pressed;
-                            dbgStWhen = out[i].when;
-                        }
-                    }
+                        if (frame.weaponSelect >= 0)
+                            base->set_weaponselect(frame.weaponSelect);
 
-                    /* ? Throw-window diagnostic */
-                    if (((b0 | b1 | b2) & kInAttack) || wsel >= 0 || dbgStBtn >= 0)
-                    {
-                        char dbg[256];
-                        std::snprintf(dbg, sizeof(dbg),
-                                      "[BL][rep] c=%d held=%llX prs=%llX rel=%llX "
-                                      "wsel=%d actDef=%d nSt=%d stBtn=%d stPr=%.2f stWhen=%.2f\n",
-                                      MotionRecorder::ReplayCursor(slot),
-                                      (unsigned long long)b0,
-                                      (unsigned long long)b1,
-                                      (unsigned long long)b2,
-                                      wsel, MotionRecorder::BotActiveWeaponDef(slot),
-                                      n, dbgStBtn, dbgStPressed, dbgStWhen);
-                        DebugOut(dbg);
+                        if (frame.subtickCount <= 0)
+                        {
+                            if (base->subtick_moves_size() > 0)
+                            {
+                                base->clear_subtick_moves();
+                                MotionRecorder::AddReplayPerf(MotionRecorder::ReplayPerfCounter::SubtickClear);
+                            }
+                            else
+                            {
+                                MotionRecorder::AddReplayPerf(MotionRecorder::ReplayPerfCounter::SubtickNoopSkip);
+                            }
+                        }
+                        else
+                        {
+                            base->clear_subtick_moves();
+                            MotionRecorder::AddReplayPerf(MotionRecorder::ReplayPerfCounter::SubtickClear);
+                            MotionRecorder::AddReplayPerf(MotionRecorder::ReplayPerfCounter::SubtickRebuild);
+                            const bool injectViewDeltas = ReplaySubtickViewDeltas();
+                            for (int i = 0; i < frame.subtickCount; ++i)
+                            {
+                                const SubtickMove &subtick = frame.subticks[i];
+                                CSubtickMoveStep *m = base->add_subtick_moves();
+                                MotionRecorder::AddReplayPerf(MotionRecorder::ReplayPerfCounter::SubticksAdded);
+                                m->set_when(subtick.when);
+                                m->set_button(subtick.button);
+                                if (subtick.button != 0) // digital press/release
+                                    m->set_pressed(subtick.pressed != 0.0f);
+                                if (injectViewDeltas && subtick.pitchDelta != 0.0f)
+                                    m->set_pitch_delta(subtick.pitchDelta);
+                                if (injectViewDeltas && subtick.yawDelta != 0.0f)
+                                    m->set_yaw_delta(subtick.yawDelta);
+                                if (subtick.analogForward != 0.0f)
+                                    m->set_analog_forward_delta(subtick.analogForward);
+                                if (subtick.analogLeft != 0.0f)
+                                    m->set_analog_left_delta(subtick.analogLeft);
+                            }
+                        }
+
+                        MotionRecorder::OnReplayCommandPre(
+                            slot, services, *frame.tick, frame.commandView);
                     }
+                }
+
+                const int currentHandednessOverride = ReplayHandednessOverride(slot);
+                if (!wroteHandedness &&
+                    currentHandednessOverride >= 0 &&
+                    !SlotIsControllingBot(slot) &&
+                    SlotIsKnownBotCommandSource(slot, services))
+                {
+                    pc->set_left_hand_desired(currentHandednessOverride != 0);
                 }
             }
 
@@ -348,17 +408,18 @@ namespace BotController
 
         static void BC_FASTCALL HookedPhysicsSimulate(void *controller)
         {
-            g_physicsSimulateCalls.fetch_add(1, std::memory_order_relaxed);
+            MotionRecorder::AddReplayPerf(MotionRecorder::ReplayPerfCounter::PhysicsSimulateHook);
             int slot = ControllerToSlot(controller);
-            g_lastPhysicsSlot.store(slot, std::memory_order_relaxed);
             void *services = (slot >= 0 && slot < kMaxSlots)
                                  ? g_slotServices[slot].load(std::memory_order_acquire)
                                  : nullptr;
 
             bool recording = slot >= 0 && slot < kMaxSlots && services &&
                              MotionRecorder::IsRecording(slot);
-            bool replaying = slot >= 0 && slot < kMaxSlots && services &&
-                             MotionRecorder::IsReplaying(slot);
+            if (slot >= 0 && slot < kMaxSlots)
+                g_slotControllingBot[slot].store(ControllerIsControllingBot(controller), std::memory_order_release);
+
+            bool replaying = services && ReplayActiveAndSafe(slot);
 
             // pre: snapshot start-of-tick state once (before any subtick mover).
             if (recording)
@@ -370,10 +431,7 @@ namespace BotController
             if (recording)
                 MotionRecorder::OnCapturePost(slot, services, nullptr);
             if (replaying)
-            {
                 MotionRecorder::OnReplayCommit(slot, services);
-                g_replayCommitCalls.fetch_add(1, std::memory_order_relaxed);
-            }
         }
 
         static std::atomic<bool> g_vtHooksTried{false};
@@ -447,7 +505,7 @@ namespace BotController
             // PhysicsSimulate: the per-tick boundary
             char psErr[256] = {0};
             g_addrPhysicsSimulate = Sig::ResolveSig(
-                gd, serverModule, "CBasePlayerController::OnSimulateUserCommands",
+                gd, serverModule, "CCSPlayer_MovementServices::PhysicsSimulate",
                 psErr, sizeof(psErr));
             if (g_addrPhysicsSimulate &&
                 g_hookPhysicsSimulate.Create(g_addrPhysicsSimulate,
@@ -504,6 +562,8 @@ namespace BotController
             g_vtHooksTried.store(false, std::memory_order_release);
             for (auto &s : g_slotServices)
                 s.store(nullptr, std::memory_order_release);
+            for (auto &taken : g_slotControllingBot)
+                taken.store(false, std::memory_order_release);
             g_installed = false;
             g_status = "not_attempted";
         }
@@ -514,19 +574,5 @@ namespace BotController
 
         uint64_t HookCallCount() { return g_hookCalls.load(std::memory_order_relaxed); }
         int LastResolvedSlot() { return g_lastSlot.load(std::memory_order_relaxed); }
-        uint64_t FinishMoveCallCount() { return g_finishMoveCalls.load(std::memory_order_relaxed); }
-        uint64_t PlayerRunCommandCallCount() { return g_playerRunCommandCalls.load(std::memory_order_relaxed); }
-        uint64_t PhysicsSimulateCallCount() { return g_physicsSimulateCalls.load(std::memory_order_relaxed); }
-        int LastPhysicsSlot() { return g_lastPhysicsSlot.load(std::memory_order_relaxed); }
-        uint64_t ReplayCommitCount() { return g_replayCommitCalls.load(std::memory_order_relaxed); }
-        uint64_t SlotResolveCallCount() { return g_slotResolveCalls.load(std::memory_order_relaxed); }
-        uint64_t SlotResolveFailureCount() { return g_slotResolveFailures.load(std::memory_order_relaxed); }
-        uintptr_t LastServices() { return g_lastServices.load(std::memory_order_relaxed); }
-        uintptr_t LastPawn() { return g_lastPawn.load(std::memory_order_relaxed); }
-        uint32_t LastControllerHandle() { return g_lastControllerHandle.load(std::memory_order_relaxed); }
-        uint32_t LastOriginalControllerHandle() { return g_lastOriginalControllerHandle.load(std::memory_order_relaxed); }
-        int LastControllerIndex() { return g_lastControllerIndex.load(std::memory_order_relaxed); }
-        int LastOriginalControllerIndex() { return g_lastOriginalControllerIndex.load(std::memory_order_relaxed); }
-        int LastOwnerSlot() { return g_lastOwnerSlot.load(std::memory_order_relaxed); }
     }
 }

--- a/src/BotRecorder/InputInjector.h
+++ b/src/BotRecorder/InputInjector.h
@@ -22,7 +22,27 @@ namespace BotController
         // Disable + remove the hooks.
         void Remove();
 
+        // Optional schema offset for CCSPlayerController::m_bControllingBot.
+        // When available, replay stops immediately if a real player takes over a bot.
+        bool SetControllerControllingBotOffset(int offset);
+
         const char *Status();
+
+        // Whether replay should inject subtick pitch_delta/yaw_delta into
+        // usercmd. Disabled by default because offline demo pawn snapshots do
+        // not prove they are aligned to CBaseUserCmdPB base viewangles.
+        void SetReplaySubtickViewDeltas(bool enabled);
+        bool ReplaySubtickViewDeltas();
+
+        // Last CCSPlayer_MovementServices* seen for this player slot.
+        void *LiveMovementServices(int slot);
+
+        // Preserve the replay's last explicit hand-side command after replay
+        // control is released, so handoff does not force a visible viewmodel
+        // side switch before the bot can fire.
+        void SetReplayHandednessOverride(int slot, bool leftHandDesired);
+        void ClearReplayHandednessOverride(int slot);
+        void ClearReplayHandednessOverrides();
 
         // Resolved address of the hooked function.
         void *ProcessUsercmdAddress();
@@ -30,19 +50,5 @@ namespace BotController
         // Diagnostics
         uint64_t HookCallCount();
         int LastResolvedSlot();
-        uint64_t FinishMoveCallCount();
-        uint64_t PlayerRunCommandCallCount();
-        uint64_t PhysicsSimulateCallCount();
-        int LastPhysicsSlot();
-        uint64_t ReplayCommitCount();
-        uint64_t SlotResolveCallCount();
-        uint64_t SlotResolveFailureCount();
-        uintptr_t LastServices();
-        uintptr_t LastPawn();
-        uint32_t LastControllerHandle();
-        uint32_t LastOriginalControllerHandle();
-        int LastControllerIndex();
-        int LastOriginalControllerIndex();
-        int LastOwnerSlot();
     }
 }

--- a/src/BotRecorder/MotionRecorder.cpp
+++ b/src/BotRecorder/MotionRecorder.cpp
@@ -1,16 +1,16 @@
 // Motion recording & replay implementation
 
 #include "MotionRecorder.h"
+#include "BotController.h"
 #include "InputInjector.h"
 #include "WeaponLocker.h"
 #include "version_targets.h"
-#include "platform.h"
+
+#include <entity2/entityinstance.h>
 
 #include <array>
 #include <atomic>
-#include <chrono>
 #include <cmath>
-#include <cstdio>
 #include <mutex>
 #include <vector>
 
@@ -41,35 +41,482 @@ namespace BotController
             std::atomic<bool> loop{false};
             std::vector<ReplayTick> ticks;
             std::vector<SubtickMove> subs;
+            std::vector<ReplayCommandFrameData> commands;
+            std::vector<ReplayMovementExtra> movementExtras;
             std::vector<uint32_t> subOffset; // prefix sum, size ticks.size()+1
             std::atomic<int> cursor{0};
+            std::atomic<int> startCursor{0};
+            std::atomic<int> holdBeforeCursor{-1};
             std::atomic<int> lastAppliedDef{-1};
-            std::mutex mu; // guards ticks/subs/subOffset
+            std::mutex mu; // guards replay buffers and offset tables
         };
 
         static std::array<RecordState, kMaxSlots> g_rec;
         static std::array<ReplayState, kMaxSlots> g_rep;
 
-        /* ! Replay-rate probe */
-        static int64_t g_lastCommitQpc[kMaxSlots] = {0};
-        /* ? Velocity-vs-displacement probe */
-        static float g_lastPostX[kMaxSlots] = {0};
-        static float g_lastPostY[kMaxSlots] = {0};
-        static bool g_haveLastPost[kMaxSlots] = {false};
-        /* ? Record-side probe */
-        static int64_t g_recLastQpc[kMaxSlots] = {0};
-        static float g_recLastNodeX[kMaxSlots] = {0};
-        static float g_recLastNodeY[kMaxSlots] = {0};
-        static bool g_recHaveLast[kMaxSlots] = {false};
+        constexpr uint64_t kPrimeAttackButtons = (1ull << 0) | (1ull << 11);
+
+        static std::atomic<int> g_replaySnapMode{static_cast<int>(ReplaySnapMode::Hard)};
+        static std::atomic<int> g_replayViewMode{static_cast<int>(ReplayViewMode::PostOnly)};
+        static std::atomic<int> g_replayCmdViewMode{static_cast<int>(ReplayCommandViewMode::Pre)};
+        static std::atomic<int> g_replayPovMode{static_cast<int>(ReplayPovMode::Spectated)};
+        static std::atomic<uint64_t> g_replayPovMask{0};
+        static std::array<uint32_t, kMaxSlots> g_serverViewChangeIndex = [] {
+            std::array<uint32_t, kMaxSlots> values{};
+            values.fill(0);
+            return values;
+        }();
+        static std::array<int, kMaxSlots> g_lastFinalViewCursor = [] {
+            std::array<int, kMaxSlots> values{};
+            values.fill(-1);
+            return values;
+        }();
+
+        struct ReplayPerfState
+        {
+            std::atomic<bool> enabled{false};
+            std::atomic<uint64_t> processMovementHooks{0};
+            std::atomic<uint64_t> finishMoveHooks{0};
+            std::atomic<uint64_t> playerRunCommandHooks{0};
+            std::atomic<uint64_t> physicsSimulateHooks{0};
+            std::atomic<uint64_t> syncReplayViewCalls{0};
+            std::atomic<uint64_t> serverViewWrites{0};
+            std::atomic<uint64_t> virtualQueryCalls{0};
+            std::atomic<uint64_t> replayTickReads{0};
+            std::atomic<uint64_t> subtickRebuilds{0};
+            std::atomic<uint64_t> subticksAdded{0};
+            std::atomic<uint64_t> replayCommandFrameReads{0};
+            std::atomic<uint64_t> subtickClears{0};
+            std::atomic<uint64_t> subtickNoopSkips{0};
+        };
+
+        static ReplayPerfState g_perf;
+
+        static constexpr float kSoftSnapDistance = 64.0f;
+        static constexpr float kSoftSnapVerticalDistance = 48.0f;
+        static constexpr float kFinishMoveResyncNudgeZ = 0.03125f;
+        static constexpr float kReplayMinEngineVelZ = -500.0f;
+        static constexpr uint8_t kMoveTypeWalk = 2;
+        static constexpr uint8_t kMoveTypeLadder = 9;
+        static constexpr float kLadderNormalResidueSq = 0.0001f;
 
         static bool ValidSlot(int s) { return s >= 0 && s < kMaxSlots; }
+        static bool CanWriteMemory(void *ptr, size_t len);
 
-        static int64_t NowMicros()
+        static bool HasLadderNormalResidue(float x, float y, float z)
         {
-            using clock = std::chrono::steady_clock;
-            return std::chrono::duration_cast<std::chrono::microseconds>(
-                       clock::now().time_since_epoch())
-                .count();
+            return x * x + y * y + z * z > kLadderNormalResidueSq;
+        }
+
+        static bool HasLadderResidue(const MovementSnapshot &s)
+        {
+            return s.moveType == kMoveTypeLadder ||
+                   s.actualMoveType == kMoveTypeLadder ||
+                   HasLadderNormalResidue(s.ladderNormalX, s.ladderNormalY,
+                                          s.ladderNormalZ);
+        }
+
+        static bool HasLadderResidue(const ReplayTick &t)
+        {
+            return HasLadderResidue(t.pre) || HasLadderResidue(t.post);
+        }
+
+        static bool ReplayStopPointHasLadderResidue(ReplayState &p)
+        {
+            const int total = static_cast<int>(p.ticks.size());
+            if (total <= 0)
+                return false;
+
+            const int cur = p.cursor.load(std::memory_order_relaxed);
+            if (cur >= 0 && cur < total &&
+                HasLadderResidue(p.ticks[static_cast<size_t>(cur)]))
+                return true;
+
+            const int prev = cur - 1;
+            return prev >= 0 && prev < total &&
+                   HasLadderResidue(p.ticks[static_cast<size_t>(prev)]);
+        }
+
+        static bool LiveMovementHasLadderResidue(void *services)
+        {
+            if (!services)
+                return false;
+            auto *sv = reinterpret_cast<char *>(services);
+            if (!CanWriteMemory(sv + tg::kServices_Pawn, sizeof(void *)))
+                return false;
+            void *pawn = *reinterpret_cast<void **>(sv + tg::kServices_Pawn);
+            if (!pawn)
+                return false;
+
+            auto *p = reinterpret_cast<char *>(pawn);
+            if (!CanWriteMemory(p + tg::kEnt_MoveType, sizeof(uint8_t)) ||
+                !CanWriteMemory(p + tg::kEnt_ActualMoveType, sizeof(uint8_t)) ||
+                !CanWriteMemory(sv + tg::kServices_LadderNormal, sizeof(float) * 3))
+                return false;
+
+            const uint8_t moveType =
+                *reinterpret_cast<uint8_t *>(p + tg::kEnt_MoveType);
+            const uint8_t actualMoveType =
+                *reinterpret_cast<uint8_t *>(p + tg::kEnt_ActualMoveType);
+            return moveType == kMoveTypeLadder ||
+                   actualMoveType == kMoveTypeLadder ||
+                   HasLadderNormalResidue(
+                       *reinterpret_cast<float *>(sv + tg::kServices_LadderNormal + 0),
+                       *reinterpret_cast<float *>(sv + tg::kServices_LadderNormal + 4),
+                       *reinterpret_cast<float *>(sv + tg::kServices_LadderNormal + 8));
+        }
+
+        static void ClearReplayStopMovementResidue(int slot, ReplayState &p)
+        {
+            void *services = InputInjector::LiveMovementServices(slot);
+            if (!services ||
+                (!ReplayStopPointHasLadderResidue(p) &&
+                 !LiveMovementHasLadderResidue(services)))
+                return;
+
+            auto *sv = reinterpret_cast<char *>(services);
+            if (!CanWriteMemory(sv + tg::kServices_Pawn, sizeof(void *)))
+                return;
+            void *pawn = *reinterpret_cast<void **>(sv + tg::kServices_Pawn);
+            if (!pawn)
+                return;
+
+            auto *pp = reinterpret_cast<char *>(pawn);
+            if (!CanWriteMemory(pp + tg::kEnt_MoveType, sizeof(uint8_t)) ||
+                !CanWriteMemory(pp + tg::kEnt_ActualMoveType, sizeof(uint8_t)) ||
+                !CanWriteMemory(pp + tg::kEnt_AbsVelocity, sizeof(float) * 3) ||
+                !CanWriteMemory(pp + tg::kEnt_Flags, sizeof(uint32_t)) ||
+                !CanWriteMemory(sv + tg::kServices_Buttons, sizeof(uint64_t) * 3) ||
+                !CanWriteMemory(sv + tg::kServices_LadderNormal, sizeof(float) * 3) ||
+                !CanWriteMemory(sv + tg::kServices_Ducked, sizeof(uint8_t)) ||
+                !CanWriteMemory(sv + tg::kServices_DesiresDuck, sizeof(uint8_t) * 2) ||
+                !CanWriteMemory(sv + tg::kServices_DuckAmount, sizeof(float) * 2))
+                return;
+
+            *reinterpret_cast<uint8_t *>(pp + tg::kEnt_MoveType) = kMoveTypeWalk;
+            *reinterpret_cast<uint8_t *>(pp + tg::kEnt_ActualMoveType) = kMoveTypeWalk;
+            *reinterpret_cast<float *>(pp + tg::kEnt_AbsVelocity + 0) = 0.0f;
+            *reinterpret_cast<float *>(pp + tg::kEnt_AbsVelocity + 4) = 0.0f;
+            *reinterpret_cast<float *>(pp + tg::kEnt_AbsVelocity + 8) = 0.0f;
+            uint32_t flags = *reinterpret_cast<uint32_t *>(pp + tg::kEnt_Flags);
+            flags &= ~tg::kFL_Ducking;
+            *reinterpret_cast<uint32_t *>(pp + tg::kEnt_Flags) = flags;
+
+            *reinterpret_cast<uint64_t *>(sv + tg::kServices_Buttons) = 0;
+            *reinterpret_cast<uint64_t *>(sv + tg::kServices_Buttons1) = 0;
+            *reinterpret_cast<uint64_t *>(sv + tg::kServices_Buttons2) = 0;
+            *reinterpret_cast<float *>(sv + tg::kServices_LadderNormal + 0) = 0.0f;
+            *reinterpret_cast<float *>(sv + tg::kServices_LadderNormal + 4) = 0.0f;
+            *reinterpret_cast<float *>(sv + tg::kServices_LadderNormal + 8) = 0.0f;
+            *reinterpret_cast<uint8_t *>(sv + tg::kServices_Ducked) = 0;
+            *reinterpret_cast<uint8_t *>(sv + tg::kServices_Ducking) = 0;
+            *reinterpret_cast<uint8_t *>(sv + tg::kServices_DesiresDuck) = 0;
+            *reinterpret_cast<float *>(sv + tg::kServices_DuckAmount) = 0.0f;
+            *reinterpret_cast<float *>(sv + tg::kServices_DuckSpeed) = 0.0f;
+        }
+
+        static void MarkNetworkStateChanged(void *entity, uint32_t offset,
+                                            int arrayIndex = -1)
+        {
+            if (!entity || offset == 0)
+                return;
+
+            NetworkStateChangedData data(offset, arrayIndex);
+            reinterpret_cast<CEntityInstance *>(entity)->NetworkStateChanged(data);
+        }
+
+        static void MarkReplayViewNetworkChanged(void *pawn, int serverViewElement)
+        {
+            if (!pawn || serverViewElement < 0)
+                return;
+
+            MarkNetworkStateChanged(
+                pawn,
+                static_cast<uint32_t>(tg::kPawn_ServerViewAngleChanges),
+                serverViewElement);
+        }
+
+        static float NormalizeDeg(float a)
+        {
+            a = std::fmod(a + 180.0f, 360.0f);
+            if (a < 0.0f)
+                a += 360.0f;
+            return a - 180.0f;
+        }
+
+        static ReplaySnapMode ActiveReplaySnapMode()
+        {
+            switch (g_replaySnapMode.load(std::memory_order_relaxed))
+            {
+            case static_cast<int>(ReplaySnapMode::Soft):
+                return ReplaySnapMode::Soft;
+            case static_cast<int>(ReplaySnapMode::Off):
+                return ReplaySnapMode::Off;
+            default:
+                return ReplaySnapMode::Hard;
+            }
+        }
+
+        static ReplayViewMode ActiveReplayViewMode()
+        {
+            switch (g_replayViewMode.load(std::memory_order_relaxed))
+            {
+            case static_cast<int>(ReplayViewMode::PostOnly):
+                return ReplayViewMode::PostOnly;
+            case static_cast<int>(ReplayViewMode::Cmd):
+                return ReplayViewMode::Cmd;
+            default:
+                return ReplayViewMode::PrePost;
+            }
+        }
+
+        static ReplayCommandViewMode ActiveReplayCommandViewMode()
+        {
+            switch (g_replayCmdViewMode.load(std::memory_order_relaxed))
+            {
+            case static_cast<int>(ReplayCommandViewMode::Post):
+                return ReplayCommandViewMode::Post;
+            case static_cast<int>(ReplayCommandViewMode::NextPre):
+                return ReplayCommandViewMode::NextPre;
+            default:
+                return ReplayCommandViewMode::Pre;
+            }
+        }
+
+        static ReplayPovMode ActiveReplayPovMode()
+        {
+            switch (g_replayPovMode.load(std::memory_order_relaxed))
+            {
+            case static_cast<int>(ReplayPovMode::Off):
+                return ReplayPovMode::Off;
+            case static_cast<int>(ReplayPovMode::Always):
+                return ReplayPovMode::Always;
+            default:
+                return ReplayPovMode::Spectated;
+            }
+        }
+
+        static bool ShouldPublishReplayPov(int slot)
+        {
+            const ReplayPovMode mode = ActiveReplayPovMode();
+            if (mode == ReplayPovMode::Always)
+                return true;
+            if (mode == ReplayPovMode::Off || !ValidSlot(slot))
+                return false;
+            return (g_replayPovMask.load(std::memory_order_relaxed) &
+                    (uint64_t{1} << static_cast<unsigned>(slot))) != 0;
+        }
+
+        void AddReplayPerf(ReplayPerfCounter counter, uint64_t amount)
+        {
+            if (amount == 0 || !g_perf.enabled.load(std::memory_order_relaxed))
+                return;
+
+            switch (counter)
+            {
+            case ReplayPerfCounter::ProcessMovementHook:
+                g_perf.processMovementHooks.fetch_add(amount, std::memory_order_relaxed);
+                break;
+            case ReplayPerfCounter::FinishMoveHook:
+                g_perf.finishMoveHooks.fetch_add(amount, std::memory_order_relaxed);
+                break;
+            case ReplayPerfCounter::PlayerRunCommandHook:
+                g_perf.playerRunCommandHooks.fetch_add(amount, std::memory_order_relaxed);
+                break;
+            case ReplayPerfCounter::PhysicsSimulateHook:
+                g_perf.physicsSimulateHooks.fetch_add(amount, std::memory_order_relaxed);
+                break;
+            case ReplayPerfCounter::SyncReplayView:
+                g_perf.syncReplayViewCalls.fetch_add(amount, std::memory_order_relaxed);
+                break;
+            case ReplayPerfCounter::ServerViewWrite:
+                g_perf.serverViewWrites.fetch_add(amount, std::memory_order_relaxed);
+                break;
+            case ReplayPerfCounter::VirtualQuery:
+                g_perf.virtualQueryCalls.fetch_add(amount, std::memory_order_relaxed);
+                break;
+            case ReplayPerfCounter::ReplayTickRead:
+                g_perf.replayTickReads.fetch_add(amount, std::memory_order_relaxed);
+                break;
+            case ReplayPerfCounter::SubtickRebuild:
+                g_perf.subtickRebuilds.fetch_add(amount, std::memory_order_relaxed);
+                break;
+            case ReplayPerfCounter::SubticksAdded:
+                g_perf.subticksAdded.fetch_add(amount, std::memory_order_relaxed);
+                break;
+            case ReplayPerfCounter::ReplayCommandFrameRead:
+                g_perf.replayCommandFrameReads.fetch_add(amount, std::memory_order_relaxed);
+                break;
+            case ReplayPerfCounter::SubtickClear:
+                g_perf.subtickClears.fetch_add(amount, std::memory_order_relaxed);
+                break;
+            case ReplayPerfCounter::SubtickNoopSkip:
+                g_perf.subtickNoopSkips.fetch_add(amount, std::memory_order_relaxed);
+                break;
+            }
+        }
+
+        void SetReplayPerfEnabled(bool enabled)
+        {
+            g_perf.enabled.store(enabled, std::memory_order_relaxed);
+        }
+
+        bool ReplayPerfEnabled()
+        {
+            return g_perf.enabled.load(std::memory_order_relaxed);
+        }
+
+        void ResetReplayPerfCounters()
+        {
+            g_perf.processMovementHooks.store(0, std::memory_order_relaxed);
+            g_perf.finishMoveHooks.store(0, std::memory_order_relaxed);
+            g_perf.playerRunCommandHooks.store(0, std::memory_order_relaxed);
+            g_perf.physicsSimulateHooks.store(0, std::memory_order_relaxed);
+            g_perf.syncReplayViewCalls.store(0, std::memory_order_relaxed);
+            g_perf.serverViewWrites.store(0, std::memory_order_relaxed);
+            g_perf.virtualQueryCalls.store(0, std::memory_order_relaxed);
+            g_perf.replayTickReads.store(0, std::memory_order_relaxed);
+            g_perf.subtickRebuilds.store(0, std::memory_order_relaxed);
+            g_perf.subticksAdded.store(0, std::memory_order_relaxed);
+            g_perf.replayCommandFrameReads.store(0, std::memory_order_relaxed);
+            g_perf.subtickClears.store(0, std::memory_order_relaxed);
+            g_perf.subtickNoopSkips.store(0, std::memory_order_relaxed);
+        }
+
+        ReplayPerfCounters GetReplayPerfCounters()
+        {
+            return ReplayPerfCounters{
+                g_perf.processMovementHooks.load(std::memory_order_relaxed),
+                g_perf.finishMoveHooks.load(std::memory_order_relaxed),
+                g_perf.playerRunCommandHooks.load(std::memory_order_relaxed),
+                g_perf.physicsSimulateHooks.load(std::memory_order_relaxed),
+                g_perf.syncReplayViewCalls.load(std::memory_order_relaxed),
+                g_perf.serverViewWrites.load(std::memory_order_relaxed),
+                g_perf.virtualQueryCalls.load(std::memory_order_relaxed),
+                g_perf.replayTickReads.load(std::memory_order_relaxed),
+                g_perf.subtickRebuilds.load(std::memory_order_relaxed),
+                g_perf.subticksAdded.load(std::memory_order_relaxed),
+                g_perf.replayCommandFrameReads.load(std::memory_order_relaxed),
+                g_perf.subtickClears.load(std::memory_order_relaxed),
+                g_perf.subtickNoopSkips.load(std::memory_order_relaxed),
+            };
+        }
+
+        const char *ReplaySnapModeName(ReplaySnapMode mode)
+        {
+            switch (mode)
+            {
+            case ReplaySnapMode::Hard:
+                return "hard";
+            case ReplaySnapMode::Soft:
+                return "soft";
+            case ReplaySnapMode::Off:
+                return "off";
+            }
+            return "hard";
+        }
+
+        void SetReplaySnapMode(ReplaySnapMode mode)
+        {
+            g_replaySnapMode.store(static_cast<int>(mode), std::memory_order_relaxed);
+        }
+
+        ReplaySnapMode GetReplaySnapMode()
+        {
+            return ActiveReplaySnapMode();
+        }
+
+        const char *ReplayViewModeName(ReplayViewMode mode)
+        {
+            switch (mode)
+            {
+            case ReplayViewMode::PrePost:
+                return "prepost";
+            case ReplayViewMode::PostOnly:
+                return "post";
+            case ReplayViewMode::Cmd:
+                return "cmd";
+            }
+            return "prepost";
+        }
+
+        void SetReplayViewMode(ReplayViewMode mode)
+        {
+            g_replayViewMode.store(static_cast<int>(mode), std::memory_order_relaxed);
+        }
+
+        ReplayViewMode GetReplayViewMode()
+        {
+            return ActiveReplayViewMode();
+        }
+
+        const char *ReplayCommandViewModeName(ReplayCommandViewMode mode)
+        {
+            switch (mode)
+            {
+            case ReplayCommandViewMode::Pre:
+                return "pre";
+            case ReplayCommandViewMode::Post:
+                return "post";
+            case ReplayCommandViewMode::NextPre:
+                return "nextpre";
+            }
+            return "pre";
+        }
+
+        void SetReplayCommandViewMode(ReplayCommandViewMode mode)
+        {
+            g_replayCmdViewMode.store(static_cast<int>(mode), std::memory_order_relaxed);
+        }
+
+        ReplayCommandViewMode GetReplayCommandViewMode()
+        {
+            return ActiveReplayCommandViewMode();
+        }
+
+        const char *ReplayPovModeName(ReplayPovMode mode)
+        {
+            switch (mode)
+            {
+            case ReplayPovMode::Off:
+                return "off";
+            case ReplayPovMode::Spectated:
+                return "spectated";
+            case ReplayPovMode::Always:
+                return "always";
+            }
+            return "spectated";
+        }
+
+        void SetReplayPovMode(ReplayPovMode mode)
+        {
+            g_replayPovMode.store(static_cast<int>(mode), std::memory_order_relaxed);
+        }
+
+        ReplayPovMode GetReplayPovMode()
+        {
+            return ActiveReplayPovMode();
+        }
+
+        void SetReplayPovMask(uint64_t mask)
+        {
+            g_replayPovMask.store(mask, std::memory_order_relaxed);
+        }
+
+        bool ReplayViewAllowsEngineSetEyeAngles()
+        {
+            return ActiveReplayViewMode() == ReplayViewMode::Cmd;
+        }
+
+        static bool ShouldDirectWritePreView()
+        {
+            return ActiveReplayViewMode() == ReplayViewMode::PrePost;
+        }
+
+        static bool ShouldDirectWritePostView()
+        {
+            ReplayViewMode mode = ActiveReplayViewMode();
+            return mode == ReplayViewMode::PrePost || mode == ReplayViewMode::PostOnly;
         }
 
         // Read a MovementSnapshot from live engine state (services -> pawn).
@@ -117,6 +564,37 @@ namespace BotController
                 out.originZ = *reinterpret_cast<float *>(n + tg::kNode_AbsOrigin + 8);
             }
             return true;
+        }
+
+        static bool SnapshotPositionIsFinite(const MovementSnapshot &s)
+        {
+            return std::isfinite(s.originX) && std::isfinite(s.originY) &&
+                   std::isfinite(s.originZ);
+        }
+
+        static bool ShouldApplyMovementSnap(ReplaySnapMode mode, int cursor,
+                                            void *services, const MovementSnapshot &target)
+        {
+            if (mode == ReplaySnapMode::Hard)
+                return true;
+            if (mode == ReplaySnapMode::Off)
+                return false;
+
+            if (cursor <= 0)
+                return true;
+            if (!SnapshotPositionIsFinite(target))
+                return false;
+
+            MovementSnapshot live{};
+            if (!ReadSnapshot(services, live) || !SnapshotPositionIsFinite(live))
+                return true;
+
+            const float dx = live.originX - target.originX;
+            const float dy = live.originY - target.originY;
+            const float dz = live.originZ - target.originZ;
+            const float dist2 = dx * dx + dy * dy;
+            return dist2 > (kSoftSnapDistance * kSoftSnapDistance) ||
+                   std::fabs(dz) > kSoftSnapVerticalDistance;
         }
 
         // ---- recording ----
@@ -221,19 +699,6 @@ namespace BotController
             r.pendingSubs.clear();
             for (int i = 0; i < count; ++i)
                 r.pendingSubs.push_back(moves[i]);
-
-            /* ? Record-side subtick diagnostic */
-            for (int i = 0; i < count; ++i)
-            {
-                if (moves[i].button & 1u)
-                {
-                    char dbg[160];
-                    std::snprintf(dbg, sizeof(dbg),
-                                  "[BL][recSt] slot=%d i=%d btn=%u pressed=%.2f when=%.3f\n",
-                                  slot, i, moves[i].button, moves[i].pressed, moves[i].when);
-                    DebugOut(dbg);
-                }
-            }
         }
 
         void OnCapturePost(int slot, void *services, void *cmd)
@@ -263,57 +728,19 @@ namespace BotController
             if (def < 0)
                 def = r.currentDef.load(std::memory_order_relaxed);
 
-            int tickIdx;
-            uint32_t nSub;
             {
                 std::lock_guard<std::mutex> lk(r.mu);
                 ReplayTick t{};
                 t.pre = r.havePre ? r.pendingPre : post;
                 t.post = post;
                 t.weaponDefIndex = def;
-                nSub = static_cast<uint32_t>(r.pendingSubs.size());
-                t.numSubtick = nSub;
+                t.numSubtick = static_cast<uint32_t>(r.pendingSubs.size());
                 for (const auto &sm : r.pendingSubs)
                     r.subs.push_back(sm);
                 r.ticks.push_back(t);
                 r.pendingSubs.clear();
                 r.havePre = false;
-                tickIdx = static_cast<int>(r.ticks.size()) - 1;
             }
-
-            /* ? Record-side diagnostics */
-            int64_t now = NowMicros();
-            long long dtUs = g_recHaveLast[slot]
-                                 ? (now - g_recLastQpc[slot])
-                                 : -1;
-            float velR = std::sqrt(post.velX * post.velX + post.velY * post.velY);
-            float nodeD = -1.0f;
-            if (g_recHaveLast[slot])
-            {
-                float dx = post.originX - g_recLastNodeX[slot];
-                float dy = post.originY - g_recLastNodeY[slot];
-                nodeD = std::sqrt(dx * dx + dy * dy) * 64.0f;
-            }
-            // MoveData origin this tick (cmd == moveData)
-            float mvX = 0, mvY = 0;
-            if (cmd)
-            {
-                auto *m = reinterpret_cast<char *>(cmd);
-                mvX = *reinterpret_cast<float *>(m + tg::kMove_AbsOrigin + 0);
-                mvY = *reinterpret_cast<float *>(m + tg::kMove_AbsOrigin + 4);
-            }
-            g_recLastQpc[slot] = now;
-            g_recLastNodeX[slot] = post.originX;
-            g_recLastNodeY[slot] = post.originY;
-            g_recHaveLast[slot] = true;
-
-            char dbg[256];
-            std::snprintf(dbg, sizeof(dbg),
-                          "[BL][rec] t=%d dt_us=%lld mt=%u nSub=%u def=%d velR=%.1f nodeD=%.1f "
-                          "node=(%.1f,%.1f) mv=(%.1f,%.1f)\n",
-                          tickIdx, dtUs, (unsigned)post.moveType, nSub, def, velR, nodeD,
-                          post.originX, post.originY, mvX, mvY);
-            DebugOut(dbg);
         }
 
         int CopyTicks(int slot, ReplayTick *out, int maxTicks)
@@ -360,36 +787,189 @@ namespace BotController
             p.subOffset[p.ticks.size()] = acc;
         }
 
+        static const ReplayTick *CurrentReplayTickPtr(ReplayState &p, int &cur, int &total)
+        {
+            total = static_cast<int>(p.ticks.size());
+            cur = p.cursor.load(std::memory_order_relaxed);
+            if (cur < 0 || cur >= total)
+                return nullptr;
+            AddReplayPerf(ReplayPerfCounter::ReplayTickRead);
+            return &p.ticks[static_cast<size_t>(cur)];
+        }
+
+        static MovementSnapshot ReplayCommandViewForTick(ReplayState &p,
+                                                         int cur,
+                                                         int total,
+                                                         const ReplayTick &tick)
+        {
+            const ReplayCommandViewMode mode = ActiveReplayCommandViewMode();
+            if (mode == ReplayCommandViewMode::Post)
+                return tick.post;
+            if (mode == ReplayCommandViewMode::NextPre)
+                return (cur + 1 < total) ? p.ticks[static_cast<size_t>(cur + 1)].pre : tick.post;
+            return tick.pre;
+        }
+
+        static uint64_t ReplayPressEdgesForPreStartTick(const ReplayState &p, int index)
+        {
+            if (index < 0 || index >= static_cast<int>(p.ticks.size()))
+                return 0;
+
+            const MovementSnapshot &pre = p.ticks[static_cast<size_t>(index)].pre;
+            if (pre.buttons1 != 0 || pre.buttons2 != 0)
+                return pre.buttons1;
+
+            // Do not infer a press from the first stored context tick. If it is
+            // already held there, the hold may have begun before the bounded
+            // freeze-time window.
+            if (index == 0)
+                return 0;
+
+            const uint64_t heldPrev =
+                p.ticks[static_cast<size_t>(index - 1)].pre.buttons;
+            return pre.buttons & ~heldPrev;
+        }
+
+        static uint64_t ReplayPrimeAttackButtonsForStart(
+            const ReplayState &p,
+            int cur,
+            uint64_t heldButtons,
+            uint64_t pressButtons)
+        {
+            const int start = p.startCursor.load(std::memory_order_relaxed);
+            if (cur != start || start <= 0)
+                return 0;
+
+            const uint64_t candidates =
+                heldButtons & kPrimeAttackButtons & ~pressButtons;
+            if (candidates == 0)
+                return 0;
+
+            uint64_t found = 0;
+            for (int i = 0; i < start; ++i)
+            {
+                found |= ReplayPressEdgesForPreStartTick(p, i) & candidates;
+                if ((found & candidates) == candidates)
+                    break;
+            }
+            return found & candidates;
+        }
+
+        static int ReplayWeaponSelectForDef(int slot, int recordedDef)
+        {
+            if (recordedDef < 0 || !WeaponLockerHooks::WeaponHooksReady())
+                return -1;
+
+            void *ws = WeaponLockerHooks::WsForSlot(slot);
+            if (!ws)
+                return -1;
+
+            if (WeaponLockerHooks::ActiveWeaponDef(ws) == recordedDef)
+                return -1;
+
+            void *weapon = WeaponLockerHooks::FindWeaponByDef(ws, recordedDef);
+            if (!weapon)
+                return -1;
+            return WeaponLockerHooks::WeaponEntIndex(weapon);
+        }
+
         bool LoadReplay(int slot, const ReplayTick *ticks, int tickCount,
                         const SubtickMove *subs, int subCount)
         {
+            return LoadReplayExtended(slot, ticks, tickCount, subs, subCount,
+                                      nullptr, 0, nullptr, 0);
+        }
+
+        bool LoadReplayExtended(int slot, const ReplayTick *ticks, int tickCount,
+                                const SubtickMove *subs, int subCount,
+                                const ReplayCommandFrameData *commands,
+                                int commandCount,
+                                const ReplayMovementExtra *movementExtras,
+                                int movementExtraCount)
+        {
             if (!ValidSlot(slot) || !ticks || tickCount < 0 ||
-                (subCount > 0 && !subs))
+                subCount < 0 ||
+                (subCount > 0 && !subs) ||
+                (commandCount != 0 && commandCount != tickCount) ||
+                (commandCount > 0 && !commands) ||
+                (movementExtraCount != 0 && movementExtraCount != tickCount) ||
+                (movementExtraCount > 0 && !movementExtras))
                 return false;
             ReplayState &p = g_rep[slot];
             if (p.playing.load(std::memory_order_acquire))
                 return false; // don't swap frames mid-playback
             std::lock_guard<std::mutex> lk(p.mu);
             p.ticks.assign(ticks, ticks + tickCount);
-            p.subs.assign(subs, subs + (subCount > 0 ? subCount : 0));
+            if (subCount > 0)
+                p.subs.assign(subs, subs + subCount);
+            else
+                p.subs.clear();
+            if (commandCount > 0)
+                p.commands.assign(commands, commands + commandCount);
+            else
+                p.commands.clear();
+            if (movementExtraCount > 0)
+                p.movementExtras.assign(movementExtras, movementExtras + movementExtraCount);
+            else
+                p.movementExtras.clear();
             RebuildSubOffset(p);
             p.cursor.store(0, std::memory_order_relaxed);
+            p.startCursor.store(0, std::memory_order_relaxed);
+            p.holdBeforeCursor.store(-1, std::memory_order_relaxed);
             p.lastAppliedDef.store(-1, std::memory_order_relaxed);
+            InputInjector::ClearReplayHandednessOverride(slot);
+            g_lastFinalViewCursor[slot] = -1;
+            g_serverViewChangeIndex[slot] = 0;
             return true;
         }
 
         bool StartReplay(int slot, bool loop)
+        {
+            return StartReplayAt(slot, loop, 0);
+        }
+
+        bool StartReplayAt(int slot, bool loop, int startIndex)
         {
             if (!ValidSlot(slot))
                 return false;
             ReplayState &p = g_rep[slot];
             {
                 std::lock_guard<std::mutex> lk(p.mu);
-                if (p.ticks.empty())
+                if (p.ticks.empty() || startIndex < 0 ||
+                    startIndex >= static_cast<int>(p.ticks.size()))
                     return false;
             }
-            p.cursor.store(0, std::memory_order_relaxed);
+            p.cursor.store(startIndex, std::memory_order_relaxed);
+            p.startCursor.store(startIndex, std::memory_order_relaxed);
+            p.holdBeforeCursor.store(-1, std::memory_order_relaxed);
             p.lastAppliedDef.store(-1, std::memory_order_relaxed);
+            InputInjector::ClearReplayHandednessOverride(slot);
+            g_lastFinalViewCursor[slot] = -1;
+            g_serverViewChangeIndex[slot] = 0;
+            p.loop.store(loop, std::memory_order_relaxed);
+            p.playing.store(true, std::memory_order_release);
+            return true;
+        }
+
+        bool StartReplayUntil(int slot, bool loop, int startIndex, int holdBeforeIndex)
+        {
+            if (!ValidSlot(slot))
+                return false;
+            ReplayState &p = g_rep[slot];
+            {
+                std::lock_guard<std::mutex> lk(p.mu);
+                const int total = static_cast<int>(p.ticks.size());
+                if (total <= 0 || startIndex < 0 || startIndex >= total ||
+                    holdBeforeIndex <= startIndex || holdBeforeIndex > total)
+                    return false;
+            }
+            p.cursor.store(startIndex, std::memory_order_relaxed);
+            p.startCursor.store(startIndex, std::memory_order_relaxed);
+            p.holdBeforeCursor.store(holdBeforeIndex, std::memory_order_relaxed);
+            p.lastAppliedDef.store(-1, std::memory_order_relaxed);
+            InputInjector::ClearReplayHandednessOverride(slot);
+            g_lastFinalViewCursor[slot] = -1;
+            g_serverViewChangeIndex[slot] = 0;
             p.loop.store(loop, std::memory_order_relaxed);
             p.playing.store(true, std::memory_order_release);
             return true;
@@ -399,7 +979,12 @@ namespace BotController
         {
             if (!ValidSlot(slot))
                 return false;
-            g_rep[slot].playing.store(false, std::memory_order_release);
+            ReplayState &p = g_rep[slot];
+            ClearReplayStopMovementResidue(slot, p);
+            p.playing.store(false, std::memory_order_release);
+            p.holdBeforeCursor.store(-1, std::memory_order_relaxed);
+            g_lastFinalViewCursor[slot] = -1;
+            g_serverViewChangeIndex[slot] = 0;
             return true;
         }
 
@@ -428,22 +1013,143 @@ namespace BotController
             return static_cast<int>(p.ticks.size());
         }
 
-        // cursor points at the NEXT tick; the one just applied is cursor-1.
-        bool CurrentReplayTick(int slot, ReplayTick &out)
+        bool GetReplaySlotState(int slot, ReplaySlotState &out)
+        {
+            out = ReplaySlotState{0, -1, 0, -1, -1, 0};
+            if (!ValidSlot(slot))
+                return false;
+
+            ReplayState &p = g_rep[slot];
+            const bool playing = p.playing.load(std::memory_order_acquire);
+            if (!playing)
+            {
+                std::lock_guard<std::mutex> lk(p.mu);
+                out.total = static_cast<int32_t>(p.ticks.size());
+                return true;
+            }
+
+            const int total = static_cast<int>(p.ticks.size());
+            const int cursor = p.cursor.load(std::memory_order_relaxed);
+            out.playing = 1;
+            out.cursor = cursor;
+            out.total = total;
+
+            int idx = cursor - 1;
+            if (idx < 0)
+                idx = 0;
+            if (idx < 0 || idx >= total)
+                return true;
+
+            const ReplayTick &tick = p.ticks[static_cast<size_t>(idx)];
+            out.currentTickIndex = idx;
+            out.weaponDefIndex = tick.weaponDefIndex;
+            out.numSubtick = static_cast<int32_t>(tick.numSubtick);
+            return true;
+        }
+
+        bool ReplayTickForSimulation(int slot, ReplayTick &out)
         {
             if (!ValidSlot(slot))
                 return false;
             ReplayState &p = g_rep[slot];
             if (!p.playing.load(std::memory_order_acquire))
                 return false;
-            std::lock_guard<std::mutex> lk(p.mu);
-            int total = static_cast<int>(p.ticks.size());
-            int idx = p.cursor.load(std::memory_order_relaxed) - 1;
-            if (idx < 0)
-                idx = 0;
-            if (idx >= total)
+            int cur = -1;
+            int total = 0;
+            const ReplayTick *tick = CurrentReplayTickPtr(p, cur, total);
+            if (!tick)
                 return false;
-            out = p.ticks[idx];
+            out = *tick;
+            return true;
+        }
+
+        bool ReplayCommandFrameForSimulation(int slot, ReplayCommandFrame &out)
+        {
+            out = ReplayCommandFrame{};
+            if (!ValidSlot(slot))
+                return false;
+            ReplayState &p = g_rep[slot];
+            if (!p.playing.load(std::memory_order_acquire))
+                return false;
+
+            int cur = -1;
+            int total = 0;
+            const ReplayTick *tick = CurrentReplayTickPtr(p, cur, total);
+            if (!tick)
+                return false;
+
+            const MovementSnapshot &pre = tick->pre;
+            uint64_t b0 = pre.buttons;
+            uint64_t b1 = pre.buttons1;
+            uint64_t b2 = pre.buttons2;
+
+            const ReplayCommandFrameData *command = nullptr;
+            if (cur >= 0 && static_cast<size_t>(cur) < p.commands.size())
+                command = &p.commands[static_cast<size_t>(cur)];
+
+            const bool hasCommandButtons =
+                command && ((command->fields & kCommandFieldButtons) != 0);
+            if (hasCommandButtons)
+            {
+                b0 = command->buttons;
+                b1 = command->buttons1;
+                b2 = command->buttons2;
+            }
+            else if (b1 == 0 && b2 == 0)
+            {
+                uint64_t heldPrev = (cur > 0) ? p.ticks[static_cast<size_t>(cur - 1)].pre.buttons : 0;
+                b1 = b0 & ~heldPrev;
+                b2 = heldPrev & ~b0;
+            }
+            if (!hasCommandButtons)
+                b1 |= ReplayPrimeAttackButtonsForStart(p, cur, b0, b1);
+
+            const SubtickMove *subticks = nullptr;
+            int subtickCount = 0;
+            if (cur >= 0 &&
+                static_cast<size_t>(cur + 1) < p.subOffset.size())
+            {
+                const uint32_t begin = p.subOffset[static_cast<size_t>(cur)];
+                const uint32_t end = p.subOffset[static_cast<size_t>(cur + 1)];
+                subtickCount = static_cast<int>(end - begin);
+                subticks = subtickCount > 0 ? &p.subs[static_cast<size_t>(begin)] : nullptr;
+            }
+
+            out.tick = tick;
+            out.subticks = subticks;
+            out.command = command;
+            out.subtickCount = subtickCount;
+            out.weaponSelect = ReplayWeaponSelectForDef(slot, tick->weaponDefIndex);
+            out.commandView = ReplayCommandViewForTick(p, cur, total, *tick);
+            if (command && ((command->fields & kCommandFieldViewAngles) != 0))
+            {
+                out.commandView.pitch = command->pitch;
+                out.commandView.yaw = command->yaw;
+                out.commandView.roll = command->roll;
+            }
+            out.buttons0 = b0;
+            out.buttons1 = b1;
+            out.buttons2 = b2;
+            if (command)
+            {
+                out.commandFields = command->fields;
+                if ((command->fields & kCommandFieldForwardMove) != 0)
+                    out.forwardMove = command->forwardMove;
+                if ((command->fields & kCommandFieldLeftMove) != 0)
+                    out.leftMove = command->leftMove;
+                if ((command->fields & kCommandFieldUpMove) != 0)
+                    out.upMove = command->upMove;
+                if ((command->fields & kCommandFieldMouse) != 0)
+                {
+                    out.mouseDx = command->mouseDx;
+                    out.mouseDy = command->mouseDy;
+                }
+                if ((command->fields & kCommandFieldWeaponSelect) != 0)
+                    out.rawWeaponSelect = command->weaponSelect;
+                if ((command->fields & kCommandFieldLeftHand) != 0)
+                    out.leftHandDesired = command->leftHandDesired;
+            }
+            AddReplayPerf(ReplayPerfCounter::ReplayCommandFrameRead);
             return true;
         }
 
@@ -454,12 +1160,69 @@ namespace BotController
             ReplayState &p = g_rep[slot];
             if (!p.playing.load(std::memory_order_acquire))
                 return false;
-            std::lock_guard<std::mutex> lk(p.mu);
-            int total = static_cast<int>(p.ticks.size());
-            int cur = p.cursor.load(std::memory_order_relaxed);
-            if (cur < 0 || cur >= total)
+            int cur = -1;
+            int total = 0;
+            const ReplayTick *tick = CurrentReplayTickPtr(p, cur, total);
+            if (!tick)
                 return false;
-            out = p.ticks[cur].pre;
+            out = ReplayCommandViewForTick(p, cur, total, *tick);
+            return true;
+        }
+
+        bool ReplaySpectatorView(int slot, MovementSnapshot &out)
+        {
+            if (!ValidSlot(slot))
+                return false;
+            ReplayState &p = g_rep[slot];
+            if (!p.playing.load(std::memory_order_acquire))
+                return false;
+            int total = static_cast<int>(p.ticks.size());
+            if (total <= 0)
+                return false;
+
+            const int cur = p.cursor.load(std::memory_order_relaxed);
+            const int lastFinal = g_lastFinalViewCursor[slot];
+            int idx = -1;
+
+            if (lastFinal >= 0 && lastFinal < total &&
+                (lastFinal == cur || lastFinal + 1 == cur || cur >= total))
+            {
+                idx = lastFinal;
+            }
+            else if (cur >= 0 && cur < total)
+            {
+                idx = cur;
+            }
+            else if (lastFinal >= 0 && lastFinal < total)
+            {
+                idx = lastFinal;
+            }
+
+            if (idx < 0 || idx >= total)
+                return false;
+
+            AddReplayPerf(ReplayPerfCounter::ReplayTickRead);
+            out = p.ticks[static_cast<size_t>(idx)].post;
+            return true;
+        }
+
+        // Public status API: cursor points at the next tick, so the last
+        // applied tick is cursor - 1. Clamp at 0 during the opening tick.
+        bool CurrentReplayTick(int slot, ReplayTick &out)
+        {
+            if (!ValidSlot(slot))
+                return false;
+            ReplayState &p = g_rep[slot];
+            if (!p.playing.load(std::memory_order_acquire))
+                return false;
+            int total = static_cast<int>(p.ticks.size());
+            int idx = p.cursor.load(std::memory_order_relaxed) - 1;
+            if (idx < 0)
+                idx = 0;
+            if (idx >= total)
+                return false;
+            AddReplayPerf(ReplayPerfCounter::ReplayTickRead);
+            out = p.ticks[static_cast<size_t>(idx)];
             return true;
         }
 
@@ -470,18 +1233,17 @@ namespace BotController
             ReplayState &p = g_rep[slot];
             if (!p.playing.load(std::memory_order_acquire))
                 return -1;
-            std::lock_guard<std::mutex> lk(p.mu);
             int total = static_cast<int>(p.ticks.size());
             int idx = p.cursor.load(std::memory_order_relaxed);
             if (idx < 0 || idx >= total)
                 return -1;
-            uint32_t begin = p.subOffset[idx];
-            uint32_t end = p.subOffset[idx + 1];
+            uint32_t begin = p.subOffset[static_cast<size_t>(idx)];
+            uint32_t end = p.subOffset[static_cast<size_t>(idx + 1)];
             int n = static_cast<int>(end - begin);
             if (n > maxOut)
                 n = maxOut;
             for (int i = 0; i < n; ++i)
-                out[i] = p.subs[begin + i];
+                out[i] = p.subs[static_cast<size_t>(begin + i)];
             return n;
         }
 
@@ -493,21 +1255,24 @@ namespace BotController
             ReplayState &p = g_rep[slot];
             if (!p.playing.load(std::memory_order_acquire))
                 return false;
-            std::lock_guard<std::mutex> lk(p.mu);
-            int total = static_cast<int>(p.ticks.size());
-            int cur = p.cursor.load(std::memory_order_relaxed);
-            if (cur < 0 || cur >= total)
+            int cur = -1;
+            int total = 0;
+            const ReplayTick *tick = CurrentReplayTickPtr(p, cur, total);
+            if (!tick)
                 return false;
-            const MovementSnapshot &pre = p.ticks[cur].pre;
+            const MovementSnapshot &pre = tick->pre;
             b0 = pre.buttons;
             b1 = pre.buttons1;
             b2 = pre.buttons2;
             if (b1 == 0 && b2 == 0)
             {
-                uint64_t heldPrev = (cur > 0) ? p.ticks[cur - 1].pre.buttons : 0;
+                // Older offline records only stored the held mask. Keep them
+                // playable by synthesizing edge masks from adjacent ticks.
+                uint64_t heldPrev = (cur > 0) ? p.ticks[static_cast<size_t>(cur - 1)].pre.buttons : 0;
                 b1 = b0 & ~heldPrev;
                 b2 = heldPrev & ~b0;
             }
+            b1 |= ReplayPrimeAttackButtonsForStart(p, cur, b0, b1);
             return true;
         }
 
@@ -538,51 +1303,211 @@ namespace BotController
         }
 
         // Entity index for cmd.weaponselect this replay tick
-        int CurrentReplayWeaponDef(int slot)
+        int CurrentReplayWeaponSelect(int slot)
         {
             if (!ValidSlot(slot))
                 return -1;
-            ReplayState &p = g_rep[slot];
-            if (!p.playing.load(std::memory_order_acquire))
-                return -1;
-            std::lock_guard<std::mutex> lk(p.mu);
-            int total = static_cast<int>(p.ticks.size());
-            int cur = p.cursor.load(std::memory_order_relaxed);
-            if (cur < 0 || cur >= total)
-                return -1;
-            return p.ticks[cur].weaponDefIndex;
-        }
-
-        int CurrentReplayWeaponSelect(int slot)
-        {
-            if (!ValidSlot(slot) || !WeaponLockerHooks::WeaponHooksReady())
-                return -1;
 
             // Recorded def for the tick about to be simulated
-            int recordedDef = CurrentReplayWeaponDef(slot);
-            if (recordedDef < 0)
-                return -1;
-
-            void *ws = WeaponLockerHooks::WsForSlot(slot);
-            if (!ws)
-                return -1;
-
-            // Already holding the recorded weapon -> no switch
-            if (WeaponLockerHooks::ActiveWeaponDef(ws) == recordedDef)
+            int recordedDef;
             {
-                g_rep[slot].lastAppliedDef.store(recordedDef, std::memory_order_relaxed);
-                return -1;
+                ReplayState &p = g_rep[slot];
+                if (!p.playing.load(std::memory_order_acquire))
+                    return -1;
+                int cur = -1;
+                int total = 0;
+                const ReplayTick *tick = CurrentReplayTickPtr(p, cur, total);
+                if (!tick)
+                    return -1;
+                recordedDef = tick->weaponDefIndex;
             }
-
-            void *weapon = WeaponLockerHooks::FindWeaponByDef(ws, recordedDef);
-            if (!weapon)
-                return -1;
-            WeaponLockerHooks::SelectWeaponRaw(ws, weapon);
-            g_rep[slot].lastAppliedDef.store(recordedDef, std::memory_order_relaxed);
-            return WeaponLockerHooks::WeaponEntIndex(weapon);
+            return ReplayWeaponSelectForDef(slot, recordedDef);
         }
 
-        // Write replay velocity onto the pawn. View replay is driven by SetEyeAngles.
+        static void WriteRawViewAnglesToPawn(char *p, float pitch, float yaw)
+        {
+            const float normalizedYaw = NormalizeDeg(yaw);
+            *reinterpret_cast<float *>(p + tg::kPawn_ViewAngle + 0) = pitch;
+            *reinterpret_cast<float *>(p + tg::kPawn_ViewAngle + 4) = normalizedYaw;
+            *reinterpret_cast<float *>(p + tg::kPawn_ViewAngle + 8) = 0.0f;
+            *reinterpret_cast<float *>(p + tg::kPawn_EyeAngles + 0) = pitch;
+            *reinterpret_cast<float *>(p + tg::kPawn_EyeAngles + 4) = normalizedYaw;
+            *reinterpret_cast<float *>(p + tg::kPawn_EyeAngles + 8) = 0.0f;
+        }
+
+        static void WriteReplayViewHistory(void *services, char *pawn, float pitch, float yaw)
+        {
+            const float normalizedYaw = NormalizeDeg(yaw);
+            *reinterpret_cast<float *>(pawn + tg::kPawn_ViewAnglePrevious + 0) = pitch;
+            *reinterpret_cast<float *>(pawn + tg::kPawn_ViewAnglePrevious + 4) = normalizedYaw;
+            *reinterpret_cast<float *>(pawn + tg::kPawn_ViewAnglePrevious + 8) = 0.0f;
+
+            auto *sv = reinterpret_cast<char *>(services);
+            *reinterpret_cast<float *>(sv + tg::kServices_OldViewAngles + 0) = pitch;
+            *reinterpret_cast<float *>(sv + tg::kServices_OldViewAngles + 4) = normalizedYaw;
+            *reinterpret_cast<float *>(sv + tg::kServices_OldViewAngles + 8) = 0.0f;
+        }
+
+        static bool CanWriteMemory(void *ptr, size_t len)
+        {
+            if (!ptr || len == 0)
+                return false;
+
+            MEMORY_BASIC_INFORMATION mbi{};
+            AddReplayPerf(ReplayPerfCounter::VirtualQuery);
+            if (VirtualQuery(ptr, &mbi, sizeof(mbi)) == 0)
+                return false;
+            if (mbi.State != MEM_COMMIT)
+                return false;
+            if (mbi.Protect & (PAGE_GUARD | PAGE_NOACCESS))
+                return false;
+
+            const DWORD writable =
+                PAGE_READWRITE | PAGE_WRITECOPY |
+                PAGE_EXECUTE_READWRITE | PAGE_EXECUTE_WRITECOPY;
+            if ((mbi.Protect & writable) == 0)
+                return false;
+
+            const auto begin = reinterpret_cast<uintptr_t>(ptr);
+            const auto end = begin + len;
+            const auto regionEnd = reinterpret_cast<uintptr_t>(mbi.BaseAddress) + mbi.RegionSize;
+            return end >= begin && end <= regionEnd;
+        }
+
+        struct ServerViewVectorCandidate
+        {
+            const char *layout;
+            char *elements;
+            int *sizePtr;
+            int size;
+            int alloc;
+        };
+
+        static bool PlausibleServerViewVector(const ServerViewVectorCandidate &c)
+        {
+            if (!c.elements || !c.sizePtr)
+                return false;
+            if (c.size < 0 || c.alloc <= 0 || c.size > c.alloc)
+                return false;
+            if (c.alloc > 64)
+                return false;
+
+            constexpr size_t kViewChangeSize = 0x48;
+            const int elementIndex = (c.size > 0) ? (c.size - 1) : 0;
+            char *element = c.elements + static_cast<size_t>(elementIndex) * kViewChangeSize;
+            return CanWriteMemory(c.sizePtr, sizeof(int)) &&
+                   CanWriteMemory(element + 0x40, sizeof(uint32_t));
+        }
+
+        static bool ResolveServerViewVector(char *pawn, ServerViewVectorCandidate &out)
+        {
+            char *vec = pawn + tg::kPawn_ServerViewAngleChanges;
+
+            // Current hl2sdk-cs2 CUtlVector layout: int size at +0,
+            // padding, then CUtlMemory at +8 (pointer, alloc, grow).
+            ServerViewVectorCandidate sdk{};
+            sdk.layout = "sdk";
+            sdk.sizePtr = reinterpret_cast<int *>(vec + 0x00);
+            sdk.size = *sdk.sizePtr;
+            sdk.elements = *reinterpret_cast<char **>(vec + 0x08);
+            sdk.alloc = *reinterpret_cast<int *>(vec + 0x10);
+            if (PlausibleServerViewVector(sdk))
+            {
+                out = sdk;
+                return true;
+            }
+
+            // Older Source-style vectors put memory first and size later.
+            ServerViewVectorCandidate legacy{};
+            legacy.layout = "legacy";
+            legacy.elements = *reinterpret_cast<char **>(vec + 0x00);
+            legacy.alloc = *reinterpret_cast<int *>(vec + 0x08);
+            legacy.sizePtr = reinterpret_cast<int *>(vec + 0x10);
+            legacy.size = *legacy.sizePtr;
+            if (PlausibleServerViewVector(legacy))
+            {
+                out = legacy;
+                return true;
+            }
+
+            return false;
+        }
+
+        static bool WriteServerViewAngleChange(char *pawn, int slot,
+                                               const MovementSnapshot &s,
+                                               int *elementOut)
+        {
+            if (elementOut)
+                *elementOut = -1;
+
+            ServerViewVectorCandidate vec{};
+            if (!ResolveServerViewVector(pawn, vec))
+                return false;
+
+            constexpr size_t kViewChangeSize = 0x48;
+            constexpr uint32_t kFixAngleAbsolute = 1;
+            const int elementIndex = (vec.size > 0) ? (vec.size - 1) : 0;
+            char *element = vec.elements + static_cast<size_t>(elementIndex) * kViewChangeSize;
+            const float normalizedYaw = NormalizeDeg(s.yaw);
+            auto *type = reinterpret_cast<uint32_t *>(element + 0x30);
+            auto *pitch = reinterpret_cast<float *>(element + 0x34);
+            auto *yaw = reinterpret_cast<float *>(element + 0x38);
+            auto *roll = reinterpret_cast<float *>(element + 0x3C);
+            auto *index = reinterpret_cast<uint32_t *>(element + 0x40);
+
+            uint32_t next = g_serverViewChangeIndex[slot] + 1;
+            if (*index >= next)
+                next = *index + 1;
+            if (next == 0)
+                next = 1;
+
+            *type = kFixAngleAbsolute;
+            *pitch = s.pitch;
+            *yaw = normalizedYaw;
+            *roll = 0.0f;
+            *index = next;
+            g_serverViewChangeIndex[slot] = next;
+            if (vec.size == 0)
+                *vec.sizePtr = 1;
+            if (elementOut)
+                *elementOut = elementIndex;
+            return true;
+        }
+
+        static bool SyncReplayView(int slot, void *services,
+                                   const MovementSnapshot &s)
+        {
+            auto *sv = reinterpret_cast<char *>(services);
+            void *pawn = *reinterpret_cast<void **>(sv + tg::kServices_Pawn);
+            if (!pawn)
+                return false;
+            auto *p = reinterpret_cast<char *>(pawn);
+
+            BotControllerHooks::ApplyReplayEyeAngles(pawn, s.pitch, s.yaw);
+            WriteRawViewAnglesToPawn(p, s.pitch, s.yaw);
+            WriteReplayViewHistory(services, p, s.pitch, s.yaw);
+            AddReplayPerf(ReplayPerfCounter::SyncReplayView);
+            if (ShouldPublishReplayPov(slot))
+            {
+                int serverViewElement = -1;
+                if (WriteServerViewAngleChange(p, slot, s, &serverViewElement))
+                {
+                    AddReplayPerf(ReplayPerfCounter::ServerViewWrite);
+                    MarkReplayViewNetworkChanged(pawn, serverViewElement);
+                }
+            }
+            return true;
+        }
+
+        // Write velocity onto the pawn. View is controlled separately so
+        // we can A/B direct view writes without changing movement replay.
+        static float ReplayEngineVelZ(float velZ)
+        {
+            if (!std::isfinite(velZ))
+                return 0.0f;
+            return velZ < kReplayMinEngineVelZ ? kReplayMinEngineVelZ : velZ;
+        }
+
         static void WriteVelocityToPawn(void *services, const MovementSnapshot &s)
         {
             auto *sv = reinterpret_cast<char *>(services);
@@ -593,26 +1518,7 @@ namespace BotController
 
             *reinterpret_cast<float *>(p + tg::kEnt_AbsVelocity + 0) = s.velX;
             *reinterpret_cast<float *>(p + tg::kEnt_AbsVelocity + 4) = s.velY;
-            *reinterpret_cast<float *>(p + tg::kEnt_AbsVelocity + 8) = s.velZ;
-        }
-
-        static void WriteSceneNodeOrigin(void *services, const MovementSnapshot &s,
-                                         float zBias = 0.0f)
-        {
-            auto *sv = reinterpret_cast<char *>(services);
-            void *pawn = *reinterpret_cast<void **>(sv + tg::kServices_Pawn);
-            if (!pawn)
-                return;
-
-            void *node = *reinterpret_cast<void **>(
-                reinterpret_cast<char *>(pawn) + tg::kEnt_GameSceneNode);
-            if (!node)
-                return;
-
-            auto *n = reinterpret_cast<char *>(node);
-            *reinterpret_cast<float *>(n + tg::kNode_AbsOrigin + 0) = s.originX;
-            *reinterpret_cast<float *>(n + tg::kNode_AbsOrigin + 4) = s.originY;
-            *reinterpret_cast<float *>(n + tg::kNode_AbsOrigin + 8) = s.originZ + zBias;
+            *reinterpret_cast<float *>(p + tg::kEnt_AbsVelocity + 8) = ReplayEngineVelZ(s.velZ);
         }
 
         // Write origin + velocity into CMoveData.
@@ -624,10 +1530,11 @@ namespace BotController
             *reinterpret_cast<float *>(m + tg::kMove_AbsOrigin + 8) = s.originZ;
             *reinterpret_cast<float *>(m + tg::kMove_Velocity + 0) = s.velX;
             *reinterpret_cast<float *>(m + tg::kMove_Velocity + 4) = s.velY;
-            *reinterpret_cast<float *>(m + tg::kMove_Velocity + 8) = s.velZ;
+            *reinterpret_cast<float *>(m + tg::kMove_Velocity + 8) = ReplayEngineVelZ(s.velZ);
         }
 
-        static void WriteMovementServiceState(void *services, const MovementSnapshot &s)
+        static void WriteMovementServiceState(void *services,
+                                              const MovementSnapshot &s)
         {
             auto *sv = reinterpret_cast<char *>(services);
             *reinterpret_cast<float *>(sv + tg::kServices_DuckAmount) = s.duckAmount;
@@ -640,6 +1547,59 @@ namespace BotController
             *reinterpret_cast<uint8_t *>(sv + tg::kServices_DesiresDuck) = s.desiresDuck;
         }
 
+        // PlayerRunCommand (pre): weapon firing and grenade throws can consume
+        // pawn state before ProcessMovement runs, so seed the live pawn here too.
+        void OnReplayCommandPre(int slot, void *services)
+        {
+            if (!ValidSlot(slot) || !services)
+                return;
+            ReplayState &p = g_rep[slot];
+            if (!p.playing.load(std::memory_order_acquire))
+                return;
+
+            int cur = -1;
+            int total = 0;
+            const ReplayTick *t = CurrentReplayTickPtr(p, cur, total);
+            if (!t)
+                return;
+            const MovementSnapshot commandView =
+                ReplayCommandViewForTick(p, cur, total, *t);
+
+            OnReplayCommandPre(slot, services, *t, commandView);
+        }
+
+        void OnReplayCommandPre(int slot, void *services, const ReplayTick &t,
+                                const MovementSnapshot &commandView)
+        {
+            if (!ValidSlot(slot) || !services)
+                return;
+            auto *sv = reinterpret_cast<char *>(services);
+            WriteVelocityToPawn(services, t.pre);
+            WriteMovementServiceState(services, t.pre);
+
+            void *pawn = *reinterpret_cast<void **>(sv + tg::kServices_Pawn);
+            if (pawn)
+            {
+                auto *pp = reinterpret_cast<char *>(pawn);
+                *reinterpret_cast<uint8_t *>(pp + tg::kEnt_MoveType) = t.pre.moveType;
+                *reinterpret_cast<uint8_t *>(pp + tg::kEnt_ActualMoveType) = t.pre.actualMoveType;
+                void *node = *reinterpret_cast<void **>(pp + tg::kEnt_GameSceneNode);
+                if (node)
+                {
+                    auto *n = reinterpret_cast<char *>(node);
+                    *reinterpret_cast<float *>(n + tg::kNode_AbsOrigin + 0) = t.pre.originX;
+                    *reinterpret_cast<float *>(n + tg::kNode_AbsOrigin + 4) = t.pre.originY;
+                    *reinterpret_cast<float *>(n + tg::kNode_AbsOrigin + 8) = t.pre.originZ;
+                }
+
+                BotControllerHooks::ApplyReplayEyeAngles(
+                    pawn, commandView.pitch, commandView.yaw);
+                WriteRawViewAnglesToPawn(pp, commandView.pitch, commandView.yaw);
+                WriteReplayViewHistory(
+                    services, pp, commandView.pitch, commandView.yaw);
+            }
+        }
+
         // ProcessMovement (pre): seed CMoveData + pawn + moveType with pre state.
         void OnReplayPre(int slot, void *services, void *moveData)
         {
@@ -648,33 +1608,49 @@ namespace BotController
             ReplayState &p = g_rep[slot];
             if (!p.playing.load(std::memory_order_acquire))
                 return;
-            ReplayTick t{};
+            int cursor = -1;
+            int total = 0;
+            const ReplayTick *t = CurrentReplayTickPtr(p, cursor, total);
+            if (!t)
+                return; // commit handler will stop/loop
+            const ReplaySnapMode snapMode = ActiveReplaySnapMode();
+            const bool snapMovement =
+                ShouldApplyMovementSnap(snapMode, cursor, services, t->pre);
+
+            if (snapMovement)
             {
-                std::lock_guard<std::mutex> lk(p.mu);
-                int total = static_cast<int>(p.ticks.size());
-                int cur = p.cursor.load(std::memory_order_relaxed);
-                if (cur >= total)
-                    return; // commit handler will stop/loop
-                t = p.ticks[cur];
+                WriteMoveData(moveData, t->pre);
+                WriteVelocityToPawn(services, t->pre);
+                WriteMovementServiceState(services, t->pre);
             }
-            WriteMoveData(moveData, t.pre);
-            WriteVelocityToPawn(services, t.pre);
-            WriteMovementServiceState(services, t.pre);
+            if (ShouldDirectWritePreView())
+                SyncReplayView(slot, services, t->pre);
             auto *sv = reinterpret_cast<char *>(services);
             // Feed recorded buttons so the engine's Duck()/ladder logic runs
-            *reinterpret_cast<uint64_t *>(sv + tg::kServices_Buttons) = t.pre.buttons;
-            *reinterpret_cast<uint64_t *>(sv + tg::kServices_Buttons1) = t.pre.buttons1;
-            *reinterpret_cast<uint64_t *>(sv + tg::kServices_Buttons2) = t.pre.buttons2;
-            void *pawn = *reinterpret_cast<void **>(sv + tg::kServices_Pawn);
-            if (pawn)
+            *reinterpret_cast<uint64_t *>(sv + tg::kServices_Buttons) = t->pre.buttons;
+            *reinterpret_cast<uint64_t *>(sv + tg::kServices_Buttons1) = t->pre.buttons1;
+            *reinterpret_cast<uint64_t *>(sv + tg::kServices_Buttons2) = t->pre.buttons2;
+            if (snapMovement)
             {
-                auto *pp = reinterpret_cast<char *>(pawn);
-                *reinterpret_cast<uint8_t *>(pp + tg::kEnt_MoveType) = t.pre.moveType;
-                WriteSceneNodeOrigin(services, t.pre);
+                void *pawn = *reinterpret_cast<void **>(sv + tg::kServices_Pawn);
+                if (pawn)
+                {
+                    auto *pp = reinterpret_cast<char *>(pawn);
+                    *reinterpret_cast<uint8_t *>(pp + tg::kEnt_MoveType) = t->pre.moveType;
+                    void *node = *reinterpret_cast<void **>(pp + tg::kEnt_GameSceneNode);
+                    if (node)
+                    {
+                        auto *n = reinterpret_cast<char *>(node);
+                        *reinterpret_cast<float *>(n + tg::kNode_AbsOrigin + 0) = t->pre.originX;
+                        *reinterpret_cast<float *>(n + tg::kNode_AbsOrigin + 4) = t->pre.originY;
+                        *reinterpret_cast<float *>(n + tg::kNode_AbsOrigin + 8) = t->pre.originZ;
+                    }
+                }
             }
         }
 
-        // FinishMove (pre): write post snapshot into CMoveData + scene-node origin.
+        // FinishMove (pre): write post snapshot into CMoveData and force a
+        // small scene-node origin mismatch so FinishMove resyncs from MoveData.
         void OnReplayFinishMove(int slot, void *services, void *moveData)
         {
             if (!ValidSlot(slot) || !services || !moveData)
@@ -682,23 +1658,64 @@ namespace BotController
             ReplayState &p = g_rep[slot];
             if (!p.playing.load(std::memory_order_acquire))
                 return;
-            ReplayTick t{};
+            if (ActiveReplaySnapMode() != ReplaySnapMode::Hard)
+                return;
+            int cur = -1;
+            int total = 0;
+            const ReplayTick *t = CurrentReplayTickPtr(p, cur, total);
+            if (!t)
+                return;
+            auto *m = reinterpret_cast<char *>(moveData);
+            *reinterpret_cast<float *>(m + tg::kMove_AbsOrigin + 0) = t->post.originX;
+            *reinterpret_cast<float *>(m + tg::kMove_AbsOrigin + 4) = t->post.originY;
+            *reinterpret_cast<float *>(m + tg::kMove_AbsOrigin + 8) = t->post.originZ;
+            *reinterpret_cast<float *>(m + tg::kMove_Velocity + 0) = t->post.velX;
+            *reinterpret_cast<float *>(m + tg::kMove_Velocity + 4) = t->post.velY;
+            *reinterpret_cast<float *>(m + tg::kMove_Velocity + 8) = ReplayEngineVelZ(t->post.velZ);
+
+            // Force engine to resync the entity origin from MoveData
+            auto *sv = reinterpret_cast<char *>(services);
+            void *pawn = *reinterpret_cast<void **>(sv + tg::kServices_Pawn);
+            if (pawn)
             {
-                std::lock_guard<std::mutex> lk(p.mu);
-                int total = static_cast<int>(p.ticks.size());
-                int cur = p.cursor.load(std::memory_order_relaxed);
-                if (cur >= total)
-                    return;
-                t = p.ticks[cur];
+                void *node = *reinterpret_cast<void **>(
+                    reinterpret_cast<char *>(pawn) + tg::kEnt_GameSceneNode);
+                if (node)
+                {
+                    auto *n = reinterpret_cast<char *>(node);
+                    *reinterpret_cast<float *>(n + tg::kNode_AbsOrigin + 0) = t->post.originX;
+                    *reinterpret_cast<float *>(n + tg::kNode_AbsOrigin + 4) = t->post.originY;
+                    *reinterpret_cast<float *>(n + tg::kNode_AbsOrigin + 8) =
+                        t->post.originZ + kFinishMoveResyncNudgeZ;
+                }
             }
-            WriteMoveData(moveData, t.post);
-#if defined(_WIN32)
-            WriteSceneNodeOrigin(services, t.post, 1000.0f);
-#else
-            WriteSceneNodeOrigin(services, t.post);
-#endif
         }
 
+        // FinishMove (post): publish the final post view before replay commit
+        // advances the cursor. This is intentionally separate from movement
+        // commit because first-person spectator state can sample before the
+        // later PhysicsSimulate boundary.
+        void OnReplayFinalView(int slot, void *services)
+        {
+            if (!ValidSlot(slot) || !services)
+                return;
+            ReplayState &p = g_rep[slot];
+            if (!p.playing.load(std::memory_order_acquire))
+                return;
+            if (!ShouldDirectWritePostView())
+                return;
+
+            int cur = -1;
+            int total = 0;
+            const ReplayTick *t = CurrentReplayTickPtr(p, cur, total);
+            if (!t)
+                return;
+
+            SyncReplayView(slot, services, t->post);
+            g_lastFinalViewCursor[slot] = cur;
+        }
+
+        // FinishMove (post): commit post moveType/flags + advance cursor.
         void OnReplayCommit(int slot, void *services)
         {
             if (!ValidSlot(slot) || !services)
@@ -707,72 +1724,67 @@ namespace BotController
             if (!p.playing.load(std::memory_order_acquire))
                 return;
 
-            ReplayTick t{};
-            int cur, total;
+            int cur = p.cursor.load(std::memory_order_relaxed);
+            int total = static_cast<int>(p.ticks.size());
+            const ReplayTick *t = nullptr;
+            if (cur >= 0 && cur < total)
             {
-                std::lock_guard<std::mutex> lk(p.mu);
-                total = static_cast<int>(p.ticks.size());
-                cur = p.cursor.load(std::memory_order_relaxed);
+                AddReplayPerf(ReplayPerfCounter::ReplayTickRead);
+                t = &p.ticks[static_cast<size_t>(cur)];
+            }
+            else
+            {
                 if (cur >= total)
                 {
                     if (p.loop.load(std::memory_order_relaxed) && total > 0)
                     {
-                        p.cursor.store(0, std::memory_order_relaxed);
+                        p.cursor.store(
+                            p.startCursor.load(std::memory_order_relaxed),
+                            std::memory_order_relaxed);
                         p.lastAppliedDef.store(-1, std::memory_order_relaxed);
+                        g_lastFinalViewCursor[slot] = -1;
+                        g_serverViewChangeIndex[slot] = 0;
                         return;
                     }
                     p.playing.store(false, std::memory_order_release);
                     return;
                 }
-                t = p.ticks[cur];
+                return;
             }
 
             auto *sv = reinterpret_cast<char *>(services);
-            void *pawn = *reinterpret_cast<void **>(sv + tg::kServices_Pawn);
-            if (pawn)
+            const ReplaySnapMode snapMode = ActiveReplaySnapMode();
+            const bool hardSnap = snapMode == ReplaySnapMode::Hard;
+            if (hardSnap)
             {
-                auto *pp = reinterpret_cast<char *>(pawn);
-                *reinterpret_cast<uint8_t *>(pp + tg::kEnt_MoveType) = t.post.moveType;
-                *reinterpret_cast<uint8_t *>(pp + tg::kEnt_ActualMoveType) = t.post.actualMoveType;
-                // Merge ground + ducking bits from the recording, keep the rest live.
-                uint32_t live = *reinterpret_cast<uint32_t *>(pp + tg::kEnt_Flags);
-                uint32_t mask = tg::kFL_OnGround | tg::kFL_Ducking;
-                live = (live & ~mask) | (t.post.entityFlags & mask);
-                *reinterpret_cast<uint32_t *>(pp + tg::kEnt_Flags) = live;
+                void *pawn = *reinterpret_cast<void **>(sv + tg::kServices_Pawn);
+                if (pawn)
+                {
+                    auto *pp = reinterpret_cast<char *>(pawn);
+                    *reinterpret_cast<uint8_t *>(pp + tg::kEnt_MoveType) = t->post.moveType;
+                    *reinterpret_cast<uint8_t *>(pp + tg::kEnt_ActualMoveType) = t->post.actualMoveType;
+                    // Merge ground + ducking bits from the recording, keep the rest live.
+                    uint32_t live = *reinterpret_cast<uint32_t *>(pp + tg::kEnt_Flags);
+                    uint32_t mask = tg::kFL_OnGround | tg::kFL_Ducking;
+                    live = (live & ~mask) | (t->post.entityFlags & mask);
+                    *reinterpret_cast<uint32_t *>(pp + tg::kEnt_Flags) = live;
+                }
+            }
+            if (ShouldDirectWritePostView() && g_lastFinalViewCursor[slot] != cur)
+                SyncReplayView(slot, services, t->post);
+
+            if (hardSnap)
+            {
+                WriteMovementServiceState(services, t->post);
             }
 
-            WriteVelocityToPawn(services, t.post);
-            WriteSceneNodeOrigin(services, t.post);
-            WriteMovementServiceState(services, t.post);
-
+            const int holdBefore = p.holdBeforeCursor.load(std::memory_order_relaxed);
+            if (holdBefore > 0 && cur + 1 >= holdBefore)
+            {
+                p.cursor.store(holdBefore - 1, std::memory_order_relaxed);
+                return;
+            }
             p.cursor.store(cur + 1, std::memory_order_relaxed);
-
-            /* ! Rate probe */
-            int64_t now = NowMicros();
-            int64_t prev = g_lastCommitQpc[slot];
-            g_lastCommitQpc[slot] = now;
-            long long dtUs = prev ? (now - prev) : -1;
-
-            /* ? Speed probe */
-            float velR = std::sqrt(t.post.velX * t.post.velX + t.post.velY * t.post.velY);
-            float velD = -1.0f;
-            if (g_haveLastPost[slot])
-            {
-                float dx = t.post.originX - g_lastPostX[slot];
-                float dy = t.post.originY - g_lastPostY[slot];
-                velD = std::sqrt(dx * dx + dy * dy) * 64.0f;
-            }
-            g_lastPostX[slot] = t.post.originX;
-            g_lastPostY[slot] = t.post.originY;
-            g_haveLastPost[slot] = true;
-
-            char dbg[256];
-            std::snprintf(dbg, sizeof(dbg),
-                          "[BL][replay] t=%d/%d dt_us=%lld mt=%u grnd=%d velR=%.1f velD=%.1f "
-                          "post=(%.1f,%.1f,%.1f)\n",
-                          cur, total, dtUs, (unsigned)t.post.moveType, (int)(t.post.entityFlags & 1),
-                          velR, velD, t.post.originX, t.post.originY, t.post.originZ);
-            DebugOut(dbg);
         }
 
         void ClearAll()
@@ -792,13 +1804,21 @@ namespace BotController
                     std::lock_guard<std::mutex> lk(g_rep[i].mu);
                     g_rep[i].ticks.clear();
                     g_rep[i].subs.clear();
+                    g_rep[i].commands.clear();
+                    g_rep[i].movementExtras.clear();
                     g_rep[i].subOffset.clear();
                 }
                 g_rec[i].currentDef.store(-1, std::memory_order_relaxed);
                 g_rec[i].liveWs.store(nullptr, std::memory_order_relaxed);
                 g_rep[i].cursor.store(0, std::memory_order_relaxed);
+                g_rep[i].startCursor.store(0, std::memory_order_relaxed);
+                g_rep[i].holdBeforeCursor.store(-1, std::memory_order_relaxed);
                 g_rep[i].lastAppliedDef.store(-1, std::memory_order_relaxed);
+                g_lastFinalViewCursor[i] = -1;
+                g_serverViewChangeIndex[i] = 0;
             }
+            g_replayPovMask.store(0, std::memory_order_relaxed);
+            InputInjector::ClearReplayHandednessOverrides();
         }
     }
 }

--- a/src/BotRecorder/MotionRecorder.h
+++ b/src/BotRecorder/MotionRecorder.h
@@ -51,12 +51,171 @@ namespace BotController
         float pitchDelta;    // pitch_delta
         float yawDelta;      // yaw_delta
     };
+
+    struct ReplayCommandFrameData
+    {
+        float forwardMove;
+        float leftMove;
+        float upMove;
+        float pitch;
+        float yaw;
+        float roll;
+        uint64_t buttons;
+        uint64_t buttons1;
+        uint64_t buttons2;
+        int32_t mouseDx;
+        int32_t mouseDy;
+        int32_t weaponSelect;
+        uint32_t fields;
+        uint8_t leftHandDesired;
+        uint8_t _pad[3];
+    };
+
+    struct ReplayMovementExtra
+    {
+        uint32_t fields;
+        float jumpPressedTime;
+        float lastDuckTime;
+        int32_t lastActualJumpPressTick;
+        float lastActualJumpPressFrac;
+        int32_t lastUsableJumpPressTick;
+        float lastUsableJumpPressFrac;
+        int32_t lastLandedTick;
+        float lastLandedFrac;
+        float lastLandedVelocityX;
+        float lastLandedVelocityY;
+        float lastLandedVelocityZ;
+    };
 #pragma pack(pop)
+
+    static_assert(sizeof(ReplayCommandFrameData) == 68);
+    static_assert(sizeof(ReplayMovementExtra) == 48);
 
     namespace MotionRecorder
     {
         constexpr int kMaxSlots = 64;
         constexpr int kMaxSubtickPerTick = 36;
+        constexpr uint32_t kCommandFieldForwardMove = 1u << 0;
+        constexpr uint32_t kCommandFieldLeftMove = 1u << 1;
+        constexpr uint32_t kCommandFieldUpMove = 1u << 2;
+        constexpr uint32_t kCommandFieldViewAngles = 1u << 3;
+        constexpr uint32_t kCommandFieldButtons = 1u << 4;
+        constexpr uint32_t kCommandFieldMouse = 1u << 5;
+        constexpr uint32_t kCommandFieldWeaponSelect = 1u << 6;
+        constexpr uint32_t kCommandFieldLeftHand = 1u << 7;
+
+        enum class ReplaySnapMode : int
+        {
+            Hard = 0, // current behavior: write pre/post movement snapshots every tick
+            Soft = 1, // seed/correct movement only when starting or badly drifting
+            Off = 2,  // replay usercmd/subtick/view only; no movement snapshot correction
+        };
+
+        enum class ReplayViewMode : int
+        {
+            PrePost = 0, // direct-write pre and post view, matching the current stable behavior
+            PostOnly = 1, // direct-write only final post view for this server tick
+            Cmd = 2,      // let injected usercmd/subtick view update pawn eye angles
+        };
+
+        enum class ReplayCommandViewMode : int
+        {
+            Pre = 0,     // base usercmd view = current replay tick pre
+            Post = 1,    // base usercmd view = current replay tick post
+            NextPre = 2, // base usercmd view = next tick pre, falling back to current post
+        };
+
+        enum class ReplayPovMode : int
+        {
+            Off = 0,       // never publish replay-owned first-person server-view changes
+            Spectated = 1, // publish only slots marked by the CSS observer mask
+            Always = 2,    // legacy behavior: publish every replay slot every tick
+        };
+
+        enum class ReplayPerfCounter : int
+        {
+            ProcessMovementHook = 0,
+            FinishMoveHook = 1,
+            PlayerRunCommandHook = 2,
+            PhysicsSimulateHook = 3,
+            SyncReplayView = 4,
+            ServerViewWrite = 5,
+            VirtualQuery = 6,
+            ReplayTickRead = 7,
+            SubtickRebuild = 8,
+            SubticksAdded = 9,
+            ReplayCommandFrameRead = 10,
+            SubtickClear = 11,
+            SubtickNoopSkip = 12,
+        };
+
+        struct ReplayPerfCounters
+        {
+            uint64_t processMovementHooks;
+            uint64_t finishMoveHooks;
+            uint64_t playerRunCommandHooks;
+            uint64_t physicsSimulateHooks;
+            uint64_t syncReplayViewCalls;
+            uint64_t serverViewWrites;
+            uint64_t virtualQueryCalls;
+            uint64_t replayTickReads;
+            uint64_t subtickRebuilds;
+            uint64_t subticksAdded;
+            uint64_t replayCommandFrameReads;
+            uint64_t subtickClears;
+            uint64_t subtickNoopSkips;
+        };
+
+        struct ReplaySlotState
+        {
+            int32_t playing;
+            int32_t cursor;
+            int32_t total;
+            int32_t currentTickIndex;
+            int32_t weaponDefIndex;
+            int32_t numSubtick;
+        };
+
+        struct ReplayCommandFrame
+        {
+            const ReplayTick *tick;
+            const SubtickMove *subticks;
+            const ReplayCommandFrameData *command;
+            int32_t subtickCount;
+            int32_t weaponSelect;
+            MovementSnapshot commandView;
+            uint64_t buttons0;
+            uint64_t buttons1;
+            uint64_t buttons2;
+            uint32_t commandFields;
+            float forwardMove;
+            float leftMove;
+            float upMove;
+            int32_t mouseDx;
+            int32_t mouseDy;
+            int32_t rawWeaponSelect;
+            uint8_t leftHandDesired;
+        };
+
+        void SetReplaySnapMode(ReplaySnapMode mode);
+        ReplaySnapMode GetReplaySnapMode();
+        const char *ReplaySnapModeName(ReplaySnapMode mode);
+        void SetReplayViewMode(ReplayViewMode mode);
+        ReplayViewMode GetReplayViewMode();
+        const char *ReplayViewModeName(ReplayViewMode mode);
+        void SetReplayCommandViewMode(ReplayCommandViewMode mode);
+        ReplayCommandViewMode GetReplayCommandViewMode();
+        const char *ReplayCommandViewModeName(ReplayCommandViewMode mode);
+        void SetReplayPovMode(ReplayPovMode mode);
+        ReplayPovMode GetReplayPovMode();
+        const char *ReplayPovModeName(ReplayPovMode mode);
+        void SetReplayPovMask(uint64_t mask);
+        bool ReplayViewAllowsEngineSetEyeAngles();
+        void SetReplayPerfEnabled(bool enabled);
+        bool ReplayPerfEnabled();
+        void ResetReplayPerfCounters();
+        ReplayPerfCounters GetReplayPerfCounters();
+        void AddReplayPerf(ReplayPerfCounter counter, uint64_t amount = 1);
 
         // ---- recording ----
         bool StartRecord(int slot); // clears old buffer, begins capture
@@ -86,16 +245,32 @@ namespace BotController
         // Load parallel arrays into a slot's replay buffer
         bool LoadReplay(int slot, const ReplayTick *ticks, int tickCount,
                         const SubtickMove *subs, int subCount);
+        bool LoadReplayExtended(int slot, const ReplayTick *ticks, int tickCount,
+                                const SubtickMove *subs, int subCount,
+                                const ReplayCommandFrameData *commands,
+                                int commandCount,
+                                const ReplayMovementExtra *movementExtras,
+                                int movementExtraCount);
         bool StartReplay(int slot, bool loop); // play from tick 0
+        bool StartReplayAt(int slot, bool loop, int startIndex);
+        bool StartReplayUntil(int slot, bool loop, int startIndex, int holdBeforeIndex);
         bool StopReplay(int slot);             // stop + clear injection
         bool IsReplaying(int slot);
         int ReplayCursor(int slot); // current tick index, <0 if idle
         int ReplayTotal(int slot);  // loaded tick count
+        bool GetReplaySlotState(int slot, ReplaySlotState &out);
 
         // Current tick being applied this server tick
-        bool CurrentReplayTick(int slot, ReplayTick &out);
-        // Command view angles for the tick currently being simulated.
+        bool ReplayTickForSimulation(int slot, ReplayTick &out);
+        bool ReplayCommandFrameForSimulation(int slot, ReplayCommandFrame &out);
+        // Snapshot to use as injected CBaseUserCmdPB.viewangles for this tick.
         bool ReplayCommandViewSnapshot(int slot, MovementSnapshot &out);
+        // Snapshot to return from replay-owned eye-angle getters. This uses
+        // the last post view published by FinishMove when available, so camera
+        // readers do not jump one tick ahead after cursor advance.
+        bool ReplaySpectatorView(int slot, MovementSnapshot &out);
+        // Last tick already applied; used by external status readers.
+        bool CurrentReplayTick(int slot, ReplayTick &out);
         // Copy the current tick's subtick moves into out
         // Returns count, or -1 if not replaying.
         int CurrentReplaySubticks(int slot, SubtickMove *out, int maxOut);
@@ -103,6 +278,12 @@ namespace BotController
         // Buttons of the tick about to be simulated
         bool CurrentReplayInputButtons(int slot, uint64_t &b0, uint64_t &b1,
                                        uint64_t &b2);
+
+        // PlayerRunCommand (pre): seed pawn/service state before weapon input
+        // consumes view/origin/velocity for shots and grenade throws.
+        void OnReplayCommandPre(int slot, void *services);
+        void OnReplayCommandPre(int slot, void *services, const ReplayTick &tick,
+                                const MovementSnapshot &commandView);
 
         // Switch a bot to the weapon with this def index.
         bool SwitchBotWeaponByDef(int slot, int defIndex);
@@ -114,13 +295,15 @@ namespace BotController
 
         // Entity index to write into cmd.weaponselect this replay tick
         int CurrentReplayWeaponSelect(int slot);
-        int CurrentReplayWeaponDef(int slot);
 
         // ---- replay write hooks ----
-        // ProcessMovement (pre): write pre snapshot into CMoveData + pawn velocity + entity moveType
+        // ProcessMovement (pre): write pre snapshot into CMoveData + pawn angles + entity moveType
         void OnReplayPre(int slot, void *services, void *moveData);
-        // FinishMove (pre): write post snapshot into CMoveData + scene-node origin.
+        // FinishMove (pre): write post snapshot into CMoveData + force a
+        // small scene-node mismatch so FinishMove resyncs from MoveData.
         void OnReplayFinishMove(int slot, void *services, void *moveData);
+        // FinishMove (post): publish final post view before replay cursor advance.
+        void OnReplayFinalView(int slot, void *services);
         // FinishMove (post): commit post moveType/flags, advance cursor.
         void OnReplayCommit(int slot, void *services);
 

--- a/src/BuyController/BuyController.cpp
+++ b/src/BuyController/BuyController.cpp
@@ -1,17 +1,17 @@
-// Detour for BuyState::OnUpdate
+// Detour for BuyState::OnUpdate.
 
 #include "BuyController.h"
 #include "BuyControllerState.h"
 #include "ccsbot_slot.h"
-#include "version_targets.h"
 #include "dispatch.h"
 #include "hook.h"
 #include "platform.h"
+#include "version_targets.h"
 
-#include <tier0/dbg.h>
+#include <convar.h>
 #include <eiface.h>
 #include <playerslot.h>
-#include <convar.h>
+#include <tier0/dbg.h>
 
 #include <cstdint>
 #include <cstdio>
@@ -31,23 +31,22 @@ namespace BotController
         static bool g_installed = false;
         static std::string g_status = "not_attempted";
 
-        // Per-slot last seen m_isInitialDelay, for rising-edge detection
         static uint8_t g_lastInitDelay[64] = {0};
 
-        // Run "buy <alias>" server-side for a bot slot
         static void IssueBuy(int slot, const char *alias)
         {
             if (!Dispatch::g_pGameClients || slot < 0 || slot >= 64)
                 return;
+
             char line[128];
             std::snprintf(line, sizeof(line), "buy %s", alias);
             CCommand cmd;
             if (!cmd.Tokenize(line))
                 return;
+
             Dispatch::g_pGameClients->ClientCommand(CPlayerSlot(slot), cmd);
         }
 
-        // Execute a slot's whole plan in one tick, then mark vanilla done
         static void ApplyPlan(void *self, int slot)
         {
             BuyPlan plan;
@@ -55,10 +54,11 @@ namespace BotController
                 return;
 
             if (!plan.skip)
+            {
                 for (const auto &alias : plan.items)
                     IssueBuy(slot, alias.c_str());
+            }
 
-            // Tell vanilla buying is finished so it stops here and exits state
             *(reinterpret_cast<uint8_t *>(self) + tg::kBuy_DoneBuying) = 1;
 
             char dbg[128];
@@ -74,7 +74,6 @@ namespace BotController
                 return g_origOnUpdate(self, me);
 
             uint8_t init = *(reinterpret_cast<uint8_t *>(self) + tg::kBuy_InitialDelay);
-            // Rising edge of m_isInitialDelay = freshly entered BuyState this round
             if (init && !g_lastInitDelay[slot])
                 ApplyPlan(self, slot);
             g_lastInitDelay[slot] = init;

--- a/src/BuyController/BuyController.h
+++ b/src/BuyController/BuyController.h
@@ -2,21 +2,19 @@
 
 #pragma once
 
-#include <nlohmann/json.hpp>
 #include "sig_scan.h"
+
+#include <nlohmann/json.hpp>
 
 namespace BotController
 {
     namespace BuyControllerHooks
     {
-        // Resolve sig + offsets and install the detour.
         bool Install(const nlohmann::json &gd, const Sig::ModuleInfo &serverModule,
                      char *errorOut, size_t errorOutLen);
-
         void Remove();
 
         const char *Status();
-
         void *OnUpdateAddress();
     }
 }

--- a/src/BuyController/BuyControllerState.cpp
+++ b/src/BuyController/BuyControllerState.cpp
@@ -1,4 +1,4 @@
-// Per-slot bot buy plan table
+// Per-slot bot buy plan table.
 
 #include "BuyControllerState.h"
 

--- a/src/BuyController/BuyControllerState.h
+++ b/src/BuyController/BuyControllerState.h
@@ -1,4 +1,4 @@
-// Per-slot bot buy plan table
+// Per-slot bot buy plan table.
 
 #pragma once
 
@@ -7,33 +7,22 @@
 
 namespace BotController
 {
-    /* One bot's buy plan: skip=true means buy nothing this round */
     struct BuyPlan
     {
         bool skip = false;
-        std::vector<std::string> items; // ordered buy aliases
+        std::vector<std::string> items;
     };
 
     namespace BuyControllerState
     {
         constexpr int kMaxSlots = 64;
 
-        // True if this slot has any plan set (skip or item list)
         bool HasPlan(int slot);
-
-        // Replace this slot's plan
         void Set(int slot, const std::vector<std::string> &items, bool skip);
-
-        // Snapshot this slot's plan into out; false if none
         bool Copy(int slot, BuyPlan &out);
-
         void Clear(int slot);
         void ClearAll();
-
-        // Number of buy aliases for this slot (-1 if no plan, skip plan = 0)
         int ItemCount(int slot);
-
-        // Count of slots with a plan
         int CountPlans();
     }
 }

--- a/src/WeaponLocker/WeaponLocker.cpp
+++ b/src/WeaponLocker/WeaponLocker.cpp
@@ -108,11 +108,6 @@ namespace BotController
             return v - 1;
         }
 
-        static bool IsGrenadeDef(int def)
-        {
-            return def >= 43 && def <= 48;
-        }
-
         // ---- edge-triggered logging ----
 
         static int g_lastLoggedLock[64] = {0};
@@ -196,9 +191,6 @@ namespace BotController
 
             int engineSlot = LockTargetToEngineSlot(lt);
             if (engineSlot < 0 || !g_pGetSlot)
-                return g_origSelectItem(ws, weapon, flag);
-
-            if (engineSlot == 3 && weapon && IsGrenadeDef(ReadDefIndex(weapon)))
                 return g_origSelectItem(ws, weapon, flag);
 
             void *targetWeapon = g_pGetSlot(ws, engineSlot, 0xFFFFFFFFu);

--- a/src/common/ccsbot_slot.cpp
+++ b/src/common/ccsbot_slot.cpp
@@ -26,35 +26,6 @@ namespace BotController
         return static_cast<int>(h & 0x7FFFu);
     }
 
-    static int SlotFromEntityIndex(int idx)
-    {
-        if (idx < 1 || idx > 64)
-            return -1;
-        return idx - 1;
-    }
-
-    PawnControllerHandles ReadPawnControllerHandles(void *pawn)
-    {
-        PawnControllerHandles out{};
-        out.controllerIndex = -1;
-        out.originalControllerIndex = -1;
-        out.controllerSlot = -1;
-        out.ownerSlot = -1;
-
-        if (!pawn)
-            return out;
-
-        out.controllerHandle = *reinterpret_cast<uint32_t *>(
-            reinterpret_cast<char *>(pawn) + tg::kPawn_Controller);
-        out.originalControllerHandle = *reinterpret_cast<uint32_t *>(
-            reinterpret_cast<char *>(pawn) + tg::kPawn_OriginalController);
-        out.controllerIndex = EntIndexFromHandle(out.controllerHandle);
-        out.originalControllerIndex = EntIndexFromHandle(out.originalControllerHandle);
-        out.controllerSlot = SlotFromEntityIndex(out.controllerIndex);
-        out.ownerSlot = out.controllerSlot;
-        return out;
-    }
-
     static void ScanPawnForControllerHandle(void *pawn)
     {
         if (!pawn)
@@ -97,7 +68,19 @@ namespace BotController
                 out.pawnEntIndex = idx;
         }
 
-        out.slot = ReadPawnControllerHandles(pawn).ownerSlot;
+        // Read m_hController; fall back to m_hOriginalController if the
+        // primary handle isn't populated for this pawn yet.
+        uint32_t ctrlHandle = *reinterpret_cast<uint32_t *>(
+            reinterpret_cast<char *>(pawn) + tg::kPawn_Controller);
+        int ctrlIdx = EntIndexFromHandle(ctrlHandle);
+        if (ctrlIdx < 1 || ctrlIdx > 64)
+        {
+            uint32_t origHandle = *reinterpret_cast<uint32_t *>(
+                reinterpret_cast<char *>(pawn) + tg::kPawn_OriginalController);
+            ctrlIdx = EntIndexFromHandle(origHandle);
+        }
+        if (ctrlIdx >= 1 && ctrlIdx <= 64)
+            out.slot = ctrlIdx - 1;
 
         if (kEnableHandleScan)
         {
@@ -119,7 +102,12 @@ namespace BotController
     {
         if (!pawn)
             return -1;
-        return ReadPawnControllerHandles(pawn).controllerSlot;
+        uint32_t h = *reinterpret_cast<uint32_t *>(
+            reinterpret_cast<char *>(pawn) + tg::kPawn_Controller);
+        int idx = EntIndexFromHandle(h);
+        if (idx < 1 || idx > 64)
+            return -1;
+        return idx - 1;
     }
 
     // CCSPlayerController*'s own identity ehandle -> entindex -> slot.

--- a/src/common/ccsbot_slot.h
+++ b/src/common/ccsbot_slot.h
@@ -2,20 +2,8 @@
 
 #pragma once
 
-#include <cstdint>
-
 namespace BotController
 {
-    struct PawnControllerHandles
-    {
-        uint32_t controllerHandle;
-        uint32_t originalControllerHandle;
-        int controllerIndex;
-        int originalControllerIndex;
-        int controllerSlot;
-        int ownerSlot;
-    };
-
     // Diagnostic: pawn pointer + pawn entindex used in slot computation.
     struct SlotResolution
     {
@@ -34,8 +22,6 @@ namespace BotController
     // pawn->m_hController only, no m_hOriginalController fallback
     // used to detect human takeover
     int ControllerSlotForPawn(void *pawn);
-
-    PawnControllerHandles ReadPawnControllerHandles(void *pawn);
 
     // CCSPlayerController* (PhysicsSimulate arg0) -> slot via its own ehandle.
     int ControllerToSlot(void *controller);

--- a/src/common/commands.cpp
+++ b/src/common/commands.cpp
@@ -5,28 +5,34 @@
 #include "WeaponLocker.h"
 #include "BotController.h"
 #include "InputInjector.h"
+#include "MotionRecorder.h"
 #include "WeaponLockerState.h"
 #include "BotControllerState.h"
-#include "MotionRecorder.h"
-#include "BuyControllerState.h"
 #include "BuyController.h"
-#include "BotProfile.h"
+#include "BuyControllerState.h"
 
 #include <tier0/dbg.h>
 #include <convar.h>
 #include <eiface.h>
+#include <icvar.h>
+#include <networkstringtabledefs.h>
 #include <playerslot.h>
 
 #include <cstdarg>
+#include <cctype>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
+#include <fstream>
+#include <string>
+#include <vector>
 
 namespace BotController
 {
     namespace Commands
     {
         IVEngineServer2 *g_pEngine = nullptr;
+        INetworkStringTableContainer *g_pStringTables = nullptr;
 
         // ClientPrintf to the calling player, or server log if from console.
         void PrintToCaller(const CCommandContext &context, const char *fmt, ...)
@@ -124,7 +130,263 @@ namespace BotController
             }
             return "?";
         }
+
+        static bool IsSteamId64(const char *s)
+        {
+            if (!s || !*s)
+                return false;
+            size_t len = 0;
+            for (const unsigned char *p = reinterpret_cast<const unsigned char *>(s); *p; ++p)
+            {
+                if (!std::isdigit(*p))
+                    return false;
+                ++len;
+            }
+            return len >= 16 && len <= 20;
+        }
+
+        static bool ReadPngFile(const char *path, std::vector<unsigned char> &out,
+                                char *err, size_t errLen)
+        {
+            if (!path || !*path)
+            {
+                std::snprintf(err, errLen, "empty path");
+                return false;
+            }
+
+            std::ifstream file(path, std::ios::binary | std::ios::ate);
+            if (!file)
+            {
+                std::snprintf(err, errLen, "failed to open file");
+                return false;
+            }
+
+            const std::streamoff size = file.tellg();
+            if (size <= 0)
+            {
+                std::snprintf(err, errLen, "empty file");
+                return false;
+            }
+            if (size > 16 * 1024)
+            {
+                std::snprintf(err, errLen, "PNG must be 16 KiB or smaller");
+                return false;
+            }
+
+            out.resize(static_cast<size_t>(size));
+            file.seekg(0, std::ios::beg);
+            if (!file.read(reinterpret_cast<char *>(out.data()), size))
+            {
+                std::snprintf(err, errLen, "failed to read file");
+                return false;
+            }
+
+            static constexpr unsigned char kPngSig[8] =
+                {0x89, 'P', 'N', 'G', 0x0d, 0x0a, 0x1a, 0x0a};
+            if (out.size() < sizeof(kPngSig) ||
+                std::memcmp(out.data(), kPngSig, sizeof(kPngSig)) != 0)
+            {
+                std::snprintf(err, errLen, "file is not a PNG");
+                return false;
+            }
+            return true;
+        }
+
+        static bool SetAvatarOverride(INetworkStringTable *table, const char *steamId,
+                                      const std::vector<unsigned char> &bytes, int &index)
+        {
+            SetStringUserDataRequest_t userData{};
+            userData.m_pRawData = const_cast<unsigned char *>(bytes.data());
+            userData.m_cbDataSize = static_cast<unsigned int>(bytes.size());
+
+            index = table->FindStringIndex(steamId);
+            if (index < 0)
+            {
+                index = table->AddString(true, steamId, &userData);
+                return index >= 0;
+            }
+            return table->SetStringUserData(index, &userData, true);
+        }
+
+        static bool EnsureReliableAvatarData(const CCommandContext &context)
+        {
+            ConVarRefAbstract reliableAvatarData("sv_reliableavatardata");
+            if (!reliableAvatarData.IsValidRef() ||
+                !reliableAvatarData.IsConVarDataAvailable())
+            {
+                PrintToCaller(
+                    context,
+                    "[BC] error: sv_reliableavatardata not found; server avatar overrides are unavailable\n");
+                return false;
+            }
+
+            if (!reliableAvatarData.GetBool())
+            {
+                reliableAvatarData.SetBool(true);
+                if (!reliableAvatarData.GetBool())
+                {
+                    PrintToCaller(
+                        context,
+                        "[BC] error: failed to enable sv_reliableavatardata; run sv_reliableavatardata true\n");
+                    return false;
+                }
+                PrintToCaller(
+                    context,
+                    "[BC] sv_reliableavatardata enabled for server avatar overrides\n");
+            }
+            return true;
+        }
+
+        static bool ParseReplaySnapMode(const char *s, MotionRecorder::ReplaySnapMode &out)
+        {
+            if (!s)
+                return false;
+            if (std::strcmp(s, "hard") == 0 || std::strcmp(s, "1") == 0)
+            {
+                out = MotionRecorder::ReplaySnapMode::Hard;
+                return true;
+            }
+            if (std::strcmp(s, "soft") == 0)
+            {
+                out = MotionRecorder::ReplaySnapMode::Soft;
+                return true;
+            }
+            if (std::strcmp(s, "off") == 0 || std::strcmp(s, "0") == 0)
+            {
+                out = MotionRecorder::ReplaySnapMode::Off;
+                return true;
+            }
+            return false;
+        }
+
+        static bool ParseReplayViewMode(const char *s, MotionRecorder::ReplayViewMode &out)
+        {
+            if (!s)
+                return false;
+            if (std::strcmp(s, "prepost") == 0 || std::strcmp(s, "hard") == 0)
+            {
+                out = MotionRecorder::ReplayViewMode::PrePost;
+                return true;
+            }
+            if (std::strcmp(s, "post") == 0 || std::strcmp(s, "postonly") == 0)
+            {
+                out = MotionRecorder::ReplayViewMode::PostOnly;
+                return true;
+            }
+            if (std::strcmp(s, "cmd") == 0 || std::strcmp(s, "usercmd") == 0)
+            {
+                out = MotionRecorder::ReplayViewMode::Cmd;
+                return true;
+            }
+            return false;
+        }
+
+        static bool ParseReplayCommandViewMode(const char *s, MotionRecorder::ReplayCommandViewMode &out)
+        {
+            if (!s)
+                return false;
+            if (std::strcmp(s, "pre") == 0)
+            {
+                out = MotionRecorder::ReplayCommandViewMode::Pre;
+                return true;
+            }
+            if (std::strcmp(s, "post") == 0)
+            {
+                out = MotionRecorder::ReplayCommandViewMode::Post;
+                return true;
+            }
+            if (std::strcmp(s, "nextpre") == 0 || std::strcmp(s, "next") == 0)
+            {
+                out = MotionRecorder::ReplayCommandViewMode::NextPre;
+                return true;
+            }
+            return false;
+        }
+
+        static bool ParseReplayPovMode(const char *s, MotionRecorder::ReplayPovMode &out)
+        {
+            if (!s)
+                return false;
+            if (std::strcmp(s, "off") == 0 || std::strcmp(s, "0") == 0)
+            {
+                out = MotionRecorder::ReplayPovMode::Off;
+                return true;
+            }
+            if (std::strcmp(s, "spectated") == 0 || std::strcmp(s, "spec") == 0)
+            {
+                out = MotionRecorder::ReplayPovMode::Spectated;
+                return true;
+            }
+            if (std::strcmp(s, "always") == 0 || std::strcmp(s, "1") == 0)
+            {
+                out = MotionRecorder::ReplayPovMode::Always;
+                return true;
+            }
+            return false;
+        }
     }
+}
+
+CON_COMMAND_F(bc_avatar_override_probe,
+              "bc_avatar_override_probe <steamid64> <png_path>  "
+              "Experimental: set ServerAvatarOverrides user data for one SteamID.",
+              FCVAR_NONE)
+{
+    using namespace BotController;
+
+    if (args.ArgC() < 3)
+    {
+        Commands::PrintToCaller(context,
+                                "usage: bc_avatar_override_probe <steamid64> <png_path>\n");
+        return;
+    }
+
+    const char *steamId = args.Arg(1);
+    if (!Commands::IsSteamId64(steamId))
+    {
+        Commands::PrintToCaller(context, "[BC] error: expected a SteamID64 key\n");
+        return;
+    }
+
+    if (!Commands::g_pStringTables)
+    {
+        Commands::PrintToCaller(context,
+                                "[BC] error: network string table server interface unavailable\n");
+        return;
+    }
+
+    INetworkStringTable *table =
+        Commands::g_pStringTables->FindTable("ServerAvatarOverrides");
+    if (!table)
+    {
+        Commands::PrintToCaller(context,
+                                "[BC] error: ServerAvatarOverrides table not found yet\n");
+        return;
+    }
+
+    std::vector<unsigned char> bytes;
+    char err[128] = {0};
+    if (!Commands::ReadPngFile(args.Arg(2), bytes, err, sizeof(err)))
+    {
+        Commands::PrintToCaller(context, "[BC] error: %s\n", err);
+        return;
+    }
+
+    if (!Commands::EnsureReliableAvatarData(context))
+        return;
+
+    int index = -1;
+    if (!Commands::SetAvatarOverride(table, steamId, bytes, index))
+    {
+        Commands::PrintToCaller(context,
+                                "[BC] error: failed to update avatar override for %s\n",
+                                steamId);
+        return;
+    }
+
+    Commands::PrintToCaller(context,
+                            "[BC] avatar override set %s (%zu bytes, index %d, sv_reliableavatardata=true)\n",
+                            steamId, bytes.size(), index);
 }
 
 CON_COMMAND_F(bc_lock,
@@ -249,6 +511,188 @@ CON_COMMAND_F(bc_unlock_all,
                                 "[BC] error: unlock_all failed (rc=%d)\n", rc);
 }
 
+CON_COMMAND_F(bc_replay_snap,
+              "bc_replay_snap [hard|soft|off]  Set replay movement snapshot correction mode.",
+              FCVAR_NONE)
+{
+    using namespace BotController;
+
+    if (args.ArgC() >= 2)
+    {
+        MotionRecorder::ReplaySnapMode mode;
+        if (!Commands::ParseReplaySnapMode(args.Arg(1), mode))
+        {
+            Commands::PrintToCaller(context,
+                                    "usage: bc_replay_snap [hard|soft|off]\n");
+            return;
+        }
+        MotionRecorder::SetReplaySnapMode(mode);
+    }
+
+    Commands::PrintToCaller(context, "[BC] replay_snap=%s\n",
+                            MotionRecorder::ReplaySnapModeName(
+                                MotionRecorder::GetReplaySnapMode()));
+}
+
+CON_COMMAND_F(bc_replay_view,
+              "bc_replay_view [prepost|post|cmd]  Set replay eye-angle write mode.",
+              FCVAR_NONE)
+{
+    using namespace BotController;
+
+    if (args.ArgC() >= 2)
+    {
+        MotionRecorder::ReplayViewMode mode;
+        if (!Commands::ParseReplayViewMode(args.Arg(1), mode))
+        {
+            Commands::PrintToCaller(context,
+                                    "usage: bc_replay_view [prepost|post|cmd]\n");
+            return;
+        }
+        MotionRecorder::SetReplayViewMode(mode);
+    }
+
+    Commands::PrintToCaller(context, "[BC] replay_view=%s\n",
+                            MotionRecorder::ReplayViewModeName(
+                                MotionRecorder::GetReplayViewMode()));
+}
+
+CON_COMMAND_F(bc_replay_cmd_view,
+              "bc_replay_cmd_view [pre|post|nextpre]  Set injected usercmd base view source.",
+              FCVAR_NONE)
+{
+    using namespace BotController;
+
+    if (args.ArgC() >= 2)
+    {
+        MotionRecorder::ReplayCommandViewMode mode;
+        if (!Commands::ParseReplayCommandViewMode(args.Arg(1), mode))
+        {
+            Commands::PrintToCaller(context,
+                                    "usage: bc_replay_cmd_view [pre|post|nextpre]\n");
+            return;
+        }
+        MotionRecorder::SetReplayCommandViewMode(mode);
+    }
+
+    Commands::PrintToCaller(context, "[BC] replay_cmd_view=%s\n",
+                            MotionRecorder::ReplayCommandViewModeName(
+                                MotionRecorder::GetReplayCommandViewMode()));
+}
+
+CON_COMMAND_F(bc_replay_pov,
+              "bc_replay_pov [off|spectated|always]  Set first-person replay POV publishing mode.",
+              FCVAR_NONE)
+{
+    using namespace BotController;
+
+    if (args.ArgC() >= 2)
+    {
+        MotionRecorder::ReplayPovMode mode;
+        if (!Commands::ParseReplayPovMode(args.Arg(1), mode))
+        {
+            Commands::PrintToCaller(context,
+                                    "usage: bc_replay_pov [off|spectated|always]\n");
+            return;
+        }
+        MotionRecorder::SetReplayPovMode(mode);
+    }
+
+    Commands::PrintToCaller(context, "[BC] replay_pov=%s\n",
+                            MotionRecorder::ReplayPovModeName(
+                                MotionRecorder::GetReplayPovMode()));
+}
+
+CON_COMMAND_F(bc_subtick_view_delta,
+              "bc_subtick_view_delta <0|1>  Toggle replay subtick pitch/yaw delta injection.",
+              FCVAR_NONE)
+{
+    using namespace BotController;
+
+    if (args.ArgC() >= 2)
+    {
+        if (std::strcmp(args.Arg(1), "1") == 0 ||
+            std::strcmp(args.Arg(1), "on") == 0)
+        {
+            InputInjector::SetReplaySubtickViewDeltas(true);
+        }
+        else if (std::strcmp(args.Arg(1), "0") == 0 ||
+                 std::strcmp(args.Arg(1), "off") == 0)
+        {
+            InputInjector::SetReplaySubtickViewDeltas(false);
+        }
+        else
+        {
+            Commands::PrintToCaller(context,
+                                    "usage: bc_subtick_view_delta <0|1>\n");
+            return;
+        }
+    }
+
+    Commands::PrintToCaller(context, "[BC] subtick_view_delta=%s\n",
+                            InputInjector::ReplaySubtickViewDeltas() ? "on" : "off");
+}
+
+CON_COMMAND_F(bc_perf,
+              "bc_perf [0|1|reset]  Toggle, reset, and print replay performance counters.",
+              FCVAR_NONE)
+{
+    using namespace BotController;
+
+    if (args.ArgC() >= 2)
+    {
+        if (std::strcmp(args.Arg(1), "1") == 0 ||
+            std::strcmp(args.Arg(1), "on") == 0)
+        {
+            MotionRecorder::SetReplayPerfEnabled(true);
+        }
+        else if (std::strcmp(args.Arg(1), "0") == 0 ||
+                 std::strcmp(args.Arg(1), "off") == 0)
+        {
+            MotionRecorder::SetReplayPerfEnabled(false);
+        }
+        else if (std::strcmp(args.Arg(1), "reset") == 0)
+        {
+            MotionRecorder::ResetReplayPerfCounters();
+        }
+        else
+        {
+            Commands::PrintToCaller(context,
+                                    "usage: bc_perf [0|1|reset]\n");
+            return;
+        }
+    }
+
+    const MotionRecorder::ReplayPerfCounters perf =
+        MotionRecorder::GetReplayPerfCounters();
+    Commands::PrintToCaller(context, "[BC] perf=%s replay_pov=%s\n",
+                            MotionRecorder::ReplayPerfEnabled() ? "on" : "off",
+                            MotionRecorder::ReplayPovModeName(
+                                MotionRecorder::GetReplayPovMode()));
+    Commands::PrintToCaller(
+        context,
+        "[BC] hooks: process=%llu finish=%llu usercmd=%llu physics=%llu\n",
+        (unsigned long long)perf.processMovementHooks,
+        (unsigned long long)perf.finishMoveHooks,
+        (unsigned long long)perf.playerRunCommandHooks,
+        (unsigned long long)perf.physicsSimulateHooks);
+    Commands::PrintToCaller(
+        context,
+        "[BC] replay: tick_reads=%llu command_frames=%llu sync_view=%llu server_view_writes=%llu virtual_query=%llu\n",
+        (unsigned long long)perf.replayTickReads,
+        (unsigned long long)perf.replayCommandFrameReads,
+        (unsigned long long)perf.syncReplayViewCalls,
+        (unsigned long long)perf.serverViewWrites,
+        (unsigned long long)perf.virtualQueryCalls);
+    Commands::PrintToCaller(
+        context,
+        "[BC] subtick_pb: rebuilds=%llu clears=%llu noop_skips=%llu subticks_added=%llu\n",
+        (unsigned long long)perf.subtickRebuilds,
+        (unsigned long long)perf.subtickClears,
+        (unsigned long long)perf.subtickNoopSkips,
+        (unsigned long long)perf.subticksAdded);
+}
+
 CON_COMMAND_F(bc_status,
               "bc_status  Print hook status and every per-slot lock.",
               FCVAR_NONE)
@@ -265,11 +709,14 @@ CON_COMMAND_F(bc_status,
                             WeaponLockerHooks::GetSlotAddress());
 
     Commands::PrintToCaller(context,
-                            "[BC] bot hooks:    %s | Update=%p Upkeep=%p Jump=%p\n",
+                            "[BC] bot hooks:    %s | Update=%p Upkeep=%p Jump=%p ULA=%p SEA=%p GEA=%p\n",
                             BotControllerHooks::Status(),
                             BotControllerHooks::UpdateAddress(),
                             BotControllerHooks::UpkeepAddress(),
-                            BotControllerHooks::JumpAddress());
+                            BotControllerHooks::JumpAddress(),
+                            BotControllerHooks::UpdateLookAnglesAddress(),
+                            BotControllerHooks::SetEyeAnglesAddress(),
+                            BotControllerHooks::GetEyeAnglesAddress());
 
     Commands::PrintToCaller(context,
                             "[BC] input inject: %s | ProcessUsercmd=%p\n",
@@ -277,46 +724,33 @@ CON_COMMAND_F(bc_status,
                             InputInjector::ProcessUsercmdAddress());
 
     Commands::PrintToCaller(context,
-                            "[BC] process movement hook fired: %llu times | last slot=%d\n",
+                            "[BC] usercmd hook fired: %llu times | last slot=%d\n",
                             (unsigned long long)InputInjector::HookCallCount(),
                             InputInjector::LastResolvedSlot());
 
     Commands::PrintToCaller(context,
-                            "[BC] movement detail: finish=%llu runCmd=%llu physics=%llu lastPhysicsSlot=%d commits=%llu\n",
-                            (unsigned long long)InputInjector::FinishMoveCallCount(),
-                            (unsigned long long)InputInjector::PlayerRunCommandCallCount(),
-                            (unsigned long long)InputInjector::PhysicsSimulateCallCount(),
-                            InputInjector::LastPhysicsSlot(),
-                            (unsigned long long)InputInjector::ReplayCommitCount());
-
+                            "[BC] replay_snap: %s\n",
+                            MotionRecorder::ReplaySnapModeName(
+                                MotionRecorder::GetReplaySnapMode()));
     Commands::PrintToCaller(context,
-                            "[BC] slot resolve: calls=%llu failures=%llu last services=%p pawn=%p ownerSlot=%d ctrl=0x%08X idx=%d orig=0x%08X idx=%d\n",
-                            (unsigned long long)InputInjector::SlotResolveCallCount(),
-                            (unsigned long long)InputInjector::SlotResolveFailureCount(),
-                            reinterpret_cast<void *>(InputInjector::LastServices()),
-                            reinterpret_cast<void *>(InputInjector::LastPawn()),
-                            InputInjector::LastOwnerSlot(),
-                            InputInjector::LastControllerHandle(),
-                            InputInjector::LastControllerIndex(),
-                            InputInjector::LastOriginalControllerHandle(),
-                            InputInjector::LastOriginalControllerIndex());
+                            "[BC] replay_view: %s\n",
+                            MotionRecorder::ReplayViewModeName(
+                                MotionRecorder::GetReplayViewMode()));
+    Commands::PrintToCaller(context,
+                            "[BC] replay_cmd_view: %s\n",
+                            MotionRecorder::ReplayCommandViewModeName(
+                                MotionRecorder::GetReplayCommandViewMode()));
+    Commands::PrintToCaller(context,
+                            "[BC] replay_pov: %s\n",
+                            MotionRecorder::ReplayPovModeName(
+                                MotionRecorder::GetReplayPovMode()));
+    Commands::PrintToCaller(context,
+                            "[BC] subtick_view_delta: %s\n",
+                            InputInjector::ReplaySubtickViewDeltas() ? "on" : "off");
 
-    bool printedReplayHeader = false;
-    for (int s = 0; s < MotionRecorder::kMaxSlots; ++s)
-    {
-        int cursor = MotionRecorder::ReplayCursor(s);
-        int total = MotionRecorder::ReplayTotal(s);
-        if (cursor >= 0 || total > 0)
-        {
-            if (!printedReplayHeader)
-            {
-                Commands::PrintToCaller(context, "[BC] replay slots:\n");
-                printedReplayHeader = true;
-            }
-            Commands::PrintToCaller(context, "[BC]   replay slot %2d cursor=%d total=%d\n",
-                                    s, cursor, total);
-        }
-    }
+    Commands::PrintToCaller(context, "[BC] buy hooks:       %s | OnUpdate=%p\n",
+                            BuyControllerHooks::Status(),
+                            BuyControllerHooks::OnUpdateAddress());
 
     // All lock
     int nAll = BotControllerState::CountAll();
@@ -362,10 +796,6 @@ CON_COMMAND_F(bc_status,
         }
     }
 
-    // Buy plans
-    Commands::PrintToCaller(context, "[BC] buy hooks:       %s | OnUpdate=%p\n",
-                            BuyControllerHooks::Status(),
-                            BuyControllerHooks::OnUpdateAddress());
     int nBuy = BuyControllerState::CountPlans();
     Commands::PrintToCaller(context, "[BC] buy-plan count:      %d\n", nBuy);
     if (nBuy > 0)
@@ -465,45 +895,4 @@ CON_COMMAND_F(bc_unbuy_all,
     using namespace BotController;
     BuyControllerState::ClearAll();
     Commands::PrintToCaller(context, "[BC] all buy plans cleared\n");
-}
-
-CON_COMMAND_F(bc_profile,
-              "bc_profile <slot>  Print a bot's BotProfile (skill/aim/weapon prefs).",
-              FCVAR_NONE)
-{
-    using namespace BotController;
-
-    if (args.ArgC() < 2)
-    {
-        Commands::PrintToCaller(context, "usage: bc_profile <slot>\n");
-        return;
-    }
-
-    const int slot = std::atoi(args.Arg(1));
-    BotProfileData d;
-    if (!BotProfile::ReadProfile(slot, d))
-    {
-        Commands::PrintToCaller(context,
-                                "[BC] error: no live bot on slot %d (it must have ticked once)\n",
-                                slot);
-        return;
-    }
-
-    Commands::PrintToCaller(context,
-                            "[BC] profile slot %d: skill=%.2f aggression=%.2f teamwork=%.2f\n",
-                            slot, d.skill, d.aggression, d.teamwork);
-    Commands::PrintToCaller(context,
-                            "[BC]   reaction=%.3f attackDelay=%.3f cost=%d difficulty=0x%X\n",
-                            d.reactionTime, d.attackDelay, d.cost, d.difficulty);
-    Commands::PrintToCaller(context,
-                            "[BC]   lookAtk accel=%.1f stiff=%.1f damp=%.1f\n",
-                            d.lookAccelAtk, d.lookStiffAtk, d.lookDampAtk);
-
-    // Weapon preference: item def indices in priority order
-    char line[256];
-    int n = std::snprintf(line, sizeof(line), "[BC]   weaponPref(%d):", d.weaponPrefCount);
-    for (int i = 0; i < d.weaponPrefCount && n < (int)sizeof(line) - 8; ++i)
-        n += std::snprintf(line + n, sizeof(line) - n, " %u", d.weaponPref[i]);
-    std::snprintf(line + n, sizeof(line) - n, "\n");
-    Commands::PrintToCaller(context, "%s", line);
 }

--- a/src/common/commands.h
+++ b/src/common/commands.h
@@ -2,6 +2,7 @@
 
 class CCommandContext;
 class IVEngineServer2;
+class INetworkStringTableContainer;
 
 namespace BotController
 {
@@ -10,6 +11,7 @@ namespace BotController
         // Set by plugin.cpp Load(). Used to ClientPrintf back to the player
         // who issued a console command. nullptr -> fall back to server log.
         extern IVEngineServer2 *g_pEngine;
+        extern INetworkStringTableContainer *g_pStringTables;
 
         void PrintToCaller(const CCommandContext &context, const char *fmt, ...);
     }

--- a/src/common/dispatch.h
+++ b/src/common/dispatch.h
@@ -21,7 +21,7 @@ namespace BotController
     namespace Dispatch
     {
         extern IVEngineServer2 *g_pEngine;
-        // Server-side console command executor; runs "buy" for a bot slot.
+        // Server-side command executor used for issuing bot "buy" commands.
         extern ISource2GameClients *g_pGameClients;
 
         // arg = LockTarget int for Weapon kind. quiet skips DebugLine.

--- a/src/common/exports.cpp
+++ b/src/common/exports.cpp
@@ -7,6 +7,7 @@
 #include "BotProfile.h"
 
 #include <cstdint>
+#include <cstring>
 #include <string>
 #include <vector>
 
@@ -15,6 +16,53 @@
 #else
 #define BC_EXPORT __attribute__((visibility("default")))
 #endif
+
+#ifndef BOTCONTROLLER_BUILD_ID
+#define BOTCONTROLLER_BUILD_ID "local"
+#endif
+
+namespace
+{
+    constexpr int kBotControllerAbiMajor = 16;
+    constexpr int kBotControllerAbiMinor = 1;
+    constexpr uint64_t kCapabilityReplaySlotState = 1ULL << 0;
+    constexpr uint64_t kCapabilityStartReplayAt = 1ULL << 1;
+    constexpr uint64_t kCapabilityStartReplayUntil = 1ULL << 2;
+    constexpr uint64_t kCapabilityReplayTick = 1ULL << 3;
+    constexpr uint64_t kCapabilityWeaponSwitchRead = 1ULL << 4;
+    constexpr uint64_t kCapabilityPovMask = 1ULL << 5;
+    constexpr uint64_t kCapabilityBuyPlan = 1ULL << 6;
+    constexpr uint64_t kCapabilityControllerBotOffset = 1ULL << 7;
+    constexpr uint64_t kCapabilityExtendedReplay = 1ULL << 8;
+    constexpr uint64_t kBotControllerCapabilities =
+        kCapabilityReplaySlotState |
+        kCapabilityStartReplayAt |
+        kCapabilityStartReplayUntil |
+        kCapabilityReplayTick |
+        kCapabilityWeaponSwitchRead |
+        kCapabilityPovMask |
+        kCapabilityBuyPlan |
+        kCapabilityControllerBotOffset |
+        kCapabilityExtendedReplay;
+
+#pragma pack(push, 4)
+    struct BotControllerAbiInfo
+    {
+        int32_t abiMajor;
+        int32_t abiMinor;
+        int32_t movementSnapshotSize;
+        int32_t replayTickSize;
+        int32_t subtickMoveSize;
+        int32_t replaySlotStateSize;
+        int32_t maxSlots;
+        uint64_t capabilities;
+        int32_t reserved0;
+        int32_t reserved1;
+    };
+#pragma pack(pop)
+
+    static_assert(sizeof(BotControllerAbiInfo) == 44);
+} // namespace
 
 extern "C" BC_EXPORT int BotController_Lock(int slot, int kind, int arg)
 {
@@ -42,7 +90,7 @@ extern "C" BC_EXPORT int BotController_IsLocked(int slot, int kind)
 
 extern "C" BC_EXPORT int BotController_GetVersion()
 {
-    return 12;
+    return kBotControllerAbiMajor;
 }
 
 // Read a bot's BotProfile by slot. 0 ok / -1 no live bot or null profile.
@@ -53,31 +101,75 @@ extern "C" BC_EXPORT int BotController_GetProfile(int slot, BotController::BotPr
     return BotController::BotProfile::ReadProfile(slot, *out) ? 0 : -1;
 }
 
+extern "C" BC_EXPORT int BotController_GetAbiInfo(BotControllerAbiInfo *out, int size)
+{
+    if (!out || size < static_cast<int>(sizeof(BotControllerAbiInfo)))
+        return -1;
+
+    BotControllerAbiInfo info{};
+    info.abiMajor = kBotControllerAbiMajor;
+    info.abiMinor = kBotControllerAbiMinor;
+    info.movementSnapshotSize = static_cast<int32_t>(sizeof(BotController::MovementSnapshot));
+    info.replayTickSize = static_cast<int32_t>(sizeof(BotController::ReplayTick));
+    info.subtickMoveSize = static_cast<int32_t>(sizeof(BotController::SubtickMove));
+    info.replaySlotStateSize = static_cast<int32_t>(sizeof(BotController::MotionRecorder::ReplaySlotState));
+    info.maxSlots = BotController::MotionRecorder::kMaxSlots;
+    info.capabilities = kBotControllerCapabilities;
+    std::memcpy(out, &info, sizeof(info));
+    return 0;
+}
+
+extern "C" BC_EXPORT uint64_t BotController_GetCapabilities()
+{
+    return kBotControllerCapabilities;
+}
+
+extern "C" BC_EXPORT const char *BotController_GetBuildId()
+{
+    return BOTCONTROLLER_BUILD_ID;
+}
+
+extern "C" BC_EXPORT int BotController_SetControllerControllingBotOffset(int offset)
+{
+    return BotController::InputInjector::SetControllerControllingBotOffset(offset) ? 0 : -1;
+}
+
+extern "C" BC_EXPORT int BotController_SetReplayPovMask(uint64_t mask)
+{
+    BotController::MotionRecorder::SetReplayPovMask(mask);
+    return 0;
+}
+
 // ---- Bot buy plans ----
 
-// Split a space/comma separated alias string into tokens.
-static std::vector<std::string> SplitAliases(const char *csv)
+static std::vector<std::string> SplitAliases(const char *aliases)
 {
     std::vector<std::string> out;
-    if (!csv)
+    if (!aliases)
         return out;
+
     std::string cur;
-    for (const char *p = csv; *p; ++p)
+    for (const char *p = aliases; *p; ++p)
     {
         char c = *p;
         if (c == ' ' || c == ',' || c == '\t')
         {
-            if (!cur.empty()) { out.push_back(cur); cur.clear(); }
+            if (!cur.empty())
+            {
+                out.push_back(cur);
+                cur.clear();
+            }
         }
         else
+        {
             cur.push_back(c);
+        }
     }
     if (!cur.empty())
         out.push_back(cur);
     return out;
 }
 
-// Set a slot's buy plan from a space/comma separated alias list. 0 ok.
 extern "C" BC_EXPORT int BotController_SetBuyPlan(int slot, const char *aliases)
 {
     if (slot < 0 || slot >= BotController::BuyControllerState::kMaxSlots)
@@ -86,7 +178,6 @@ extern "C" BC_EXPORT int BotController_SetBuyPlan(int slot, const char *aliases)
     return 0;
 }
 
-// Mark a slot to buy nothing this round. 0 ok.
 extern "C" BC_EXPORT int BotController_SetBuySkip(int slot)
 {
     if (slot < 0 || slot >= BotController::BuyControllerState::kMaxSlots)
@@ -109,7 +200,6 @@ extern "C" BC_EXPORT int BotController_ClearAllBuyPlans()
     return 0;
 }
 
-// Item count for a slot's plan: -1 none, 0 skip/empty, >0 alias count.
 extern "C" BC_EXPORT int BotController_GetBuyPlanItemCount(int slot)
 {
     return BotController::BuyControllerState::ItemCount(slot);
@@ -161,6 +251,20 @@ extern "C" BC_EXPORT int BotController_LoadReplay(int slot,
                : -1;
 }
 
+extern "C" BC_EXPORT int BotController_LoadReplayExtended(
+    int slot,
+    const BotController::ReplayTick *ticks, int tickCount,
+    const BotController::SubtickMove *subs, int subCount,
+    const BotController::ReplayCommandFrameData *commands, int commandCount,
+    const BotController::ReplayMovementExtra *movementExtras, int movementExtraCount)
+{
+    return BotController::MotionRecorder::LoadReplayExtended(
+               slot, ticks, tickCount, subs, subCount,
+               commands, commandCount, movementExtras, movementExtraCount)
+               ? 0
+               : -1;
+}
+
 // Move a slot's just-recorded buffers into another slot's replay buffer
 extern "C" BC_EXPORT int BotController_TransferRecordingToReplay(int srcSlot, int dstSlot)
 {
@@ -189,6 +293,20 @@ extern "C" BC_EXPORT int BotController_StartReplay(int slot, int loop)
     return BotController::MotionRecorder::StartReplay(slot, loop != 0) ? 0 : -1;
 }
 
+extern "C" BC_EXPORT int BotController_StartReplayAt(int slot, int loop, int startIndex)
+{
+    return BotController::MotionRecorder::StartReplayAt(slot, loop != 0, startIndex) ? 0 : -1;
+}
+
+extern "C" BC_EXPORT int BotController_StartReplayUntil(
+    int slot, int loop, int startIndex, int holdBeforeIndex)
+{
+    return BotController::MotionRecorder::StartReplayUntil(
+               slot, loop != 0, startIndex, holdBeforeIndex)
+               ? 0
+               : -1;
+}
+
 extern "C" BC_EXPORT int BotController_StopReplay(int slot)
 {
     return BotController::MotionRecorder::StopReplay(slot) ? 0 : -1;
@@ -204,6 +322,16 @@ extern "C" BC_EXPORT int BotController_GetReplayCursor(int slot)
 extern "C" BC_EXPORT int BotController_GetReplayTotal(int slot)
 {
     return BotController::MotionRecorder::ReplayTotal(slot);
+}
+
+// Combined replay state for CSS hot paths. Returns 0 on success.
+extern "C" BC_EXPORT int BotController_GetReplaySlotState(
+    int slot,
+    BotController::MotionRecorder::ReplaySlotState *out)
+{
+    if (!out)
+        return -1;
+    return BotController::MotionRecorder::GetReplaySlotState(slot, *out) ? 0 : -1;
 }
 
 // Copy the tick currently being replayed (for C# to drive weapon/fire).
@@ -227,84 +355,4 @@ extern "C" BC_EXPORT int BotController_SwitchBotWeapon(int slot, int defIndex)
 extern "C" BC_EXPORT int BotController_GetBotActiveWeaponDef(int slot)
 {
     return BotController::MotionRecorder::BotActiveWeaponDef(slot);
-}
-
-extern "C" BC_EXPORT uint64_t BotController_GetHookCallCount()
-{
-    return BotController::InputInjector::HookCallCount();
-}
-
-extern "C" BC_EXPORT int BotController_GetLastResolvedSlot()
-{
-    return BotController::InputInjector::LastResolvedSlot();
-}
-
-extern "C" BC_EXPORT uint64_t BotController_GetFinishMoveCallCount()
-{
-    return BotController::InputInjector::FinishMoveCallCount();
-}
-
-extern "C" BC_EXPORT uint64_t BotController_GetPlayerRunCommandCallCount()
-{
-    return BotController::InputInjector::PlayerRunCommandCallCount();
-}
-
-extern "C" BC_EXPORT uint64_t BotController_GetPhysicsSimulateCallCount()
-{
-    return BotController::InputInjector::PhysicsSimulateCallCount();
-}
-
-extern "C" BC_EXPORT int BotController_GetLastPhysicsSlot()
-{
-    return BotController::InputInjector::LastPhysicsSlot();
-}
-
-extern "C" BC_EXPORT uint64_t BotController_GetReplayCommitCount()
-{
-    return BotController::InputInjector::ReplayCommitCount();
-}
-
-extern "C" BC_EXPORT uint64_t BotController_GetSlotResolveCallCount()
-{
-    return BotController::InputInjector::SlotResolveCallCount();
-}
-
-extern "C" BC_EXPORT uint64_t BotController_GetSlotResolveFailureCount()
-{
-    return BotController::InputInjector::SlotResolveFailureCount();
-}
-
-extern "C" BC_EXPORT uint64_t BotController_GetLastServices()
-{
-    return static_cast<uint64_t>(BotController::InputInjector::LastServices());
-}
-
-extern "C" BC_EXPORT uint64_t BotController_GetLastPawn()
-{
-    return static_cast<uint64_t>(BotController::InputInjector::LastPawn());
-}
-
-extern "C" BC_EXPORT uint32_t BotController_GetLastControllerHandle()
-{
-    return BotController::InputInjector::LastControllerHandle();
-}
-
-extern "C" BC_EXPORT uint32_t BotController_GetLastOriginalControllerHandle()
-{
-    return BotController::InputInjector::LastOriginalControllerHandle();
-}
-
-extern "C" BC_EXPORT int BotController_GetLastControllerIndex()
-{
-    return BotController::InputInjector::LastControllerIndex();
-}
-
-extern "C" BC_EXPORT int BotController_GetLastOriginalControllerIndex()
-{
-    return BotController::InputInjector::LastOriginalControllerIndex();
-}
-
-extern "C" BC_EXPORT int BotController_GetLastOwnerSlot()
-{
-    return BotController::InputInjector::LastOwnerSlot();
 }

--- a/src/common/platform.cpp
+++ b/src/common/platform.cpp
@@ -14,7 +14,8 @@ namespace BotController
     void DebugOut(const char *msg)
     {
 #if defined(_WIN32)
-        OutputDebugStringA(msg);
+        if (msg)
+            OutputDebugStringA(msg);
 #else
         (void)msg;
 #endif

--- a/src/common/version_targets.cpp
+++ b/src/common/version_targets.cpp
@@ -23,8 +23,6 @@ namespace BotController::targets
         kProf_LookAccelAtk       = Sig::FindPlatformOffset(gd, "BotProfile::LookAngleMaxAccelAttacking", kProf_LookAccelAtk);
         kProf_LookStiffAtk       = Sig::FindPlatformOffset(gd, "BotProfile::LookAngleStiffnessAttacking", kProf_LookStiffAtk);
         kProf_LookDampAtk        = Sig::FindPlatformOffset(gd, "BotProfile::LookAngleDampingAttacking", kProf_LookDampAtk);
-        kBuy_InitialDelay        = Sig::FindPlatformOffset(gd, "BuyState::InitialDelay", kBuy_InitialDelay);
-        kBuy_DoneBuying          = Sig::FindPlatformOffset(gd, "BuyState::DoneBuying", kBuy_DoneBuying);
         kEnt_Identity            = Sig::FindPlatformOffset(gd, "CBaseEntity::Identity", kEnt_Identity);
         kEntIdentity_EHandle     = Sig::FindPlatformOffset(gd, "CEntityIdentity::EHandle", kEntIdentity_EHandle);
         kEnt_MoveType            = Sig::FindPlatformOffset(gd, "CBaseEntity::MoveType", kEnt_MoveType);
@@ -37,13 +35,18 @@ namespace BotController::targets
         kPawn_Controller         = Sig::FindPlatformOffset(gd, "CCSPlayerPawn::Controller", kPawn_Controller);
         kPawn_OriginalController = Sig::FindPlatformOffset(gd, "CCSPlayerPawn::OriginalController", kPawn_OriginalController);
         kPawn_ViewAngle          = Sig::FindPlatformOffset(gd, "CCSPlayerPawn::ViewAngle", kPawn_ViewAngle);
+        kPawn_ViewAnglePrevious  = Sig::FindPlatformOffset(gd, "CCSPlayerPawn::ViewAnglePrevious", kPawn_ViewAnglePrevious);
+        kPawn_ServerViewAngleChanges = Sig::FindPlatformOffset(gd, "CCSPlayerPawn::ServerViewAngleChanges", kPawn_ServerViewAngleChanges);
         kPawn_EyeAngles          = Sig::FindPlatformOffset(gd, "CCSPlayerPawn::EyeAngles", kPawn_EyeAngles);
+        kBuy_InitialDelay        = Sig::FindPlatformOffset(gd, "BuyState::InitialDelay", kBuy_InitialDelay);
+        kBuy_DoneBuying          = Sig::FindPlatformOffset(gd, "BuyState::DoneBuying", kBuy_DoneBuying);
         kWs_ActiveWeapon         = Sig::FindPlatformOffset(gd, "CCSPlayer_WeaponServices::ActiveWeapon", kWs_ActiveWeapon);
         kWeapon_ItemDefIndex     = Sig::FindPlatformOffset(gd, "CBasePlayerWeapon::ItemDefIndex", kWeapon_ItemDefIndex);
         kServices_Pawn           = Sig::FindPlatformOffset(gd, "CCSPlayer_MovementServices::Pawn", kServices_Pawn);
         kServices_Buttons        = Sig::FindPlatformOffset(gd, "CCSPlayer_MovementServices::Buttons", kServices_Buttons);
         kServices_Buttons1       = Sig::FindPlatformOffset(gd, "CCSPlayer_MovementServices::Buttons1", kServices_Buttons1);
         kServices_Buttons2       = Sig::FindPlatformOffset(gd, "CCSPlayer_MovementServices::Buttons2", kServices_Buttons2);
+        kServices_OldViewAngles  = Sig::FindPlatformOffset(gd, "CCSPlayer_MovementServices::OldViewAngles", kServices_OldViewAngles);
         kServices_LadderNormal   = Sig::FindPlatformOffset(gd, "CCSPlayer_MovementServices::LadderNormal", kServices_LadderNormal);
         kServices_Ducked         = Sig::FindPlatformOffset(gd, "CCSPlayer_MovementServices::Ducked", kServices_Ducked);
         kServices_DuckAmount     = Sig::FindPlatformOffset(gd, "CCSPlayer_MovementServices::DuckAmount", kServices_DuckAmount);

--- a/src/common/version_targets.h
+++ b/src/common/version_targets.h
@@ -17,25 +17,18 @@ namespace BotController::targets
 
     // ---- BotProfile (CCSBot+kBot_Profile) ----
 
-    inline int kProf_Aggression = 0x08;   // float, 0..1
-    inline int kProf_Skill = 0x0C;        // float, 0..1
-    inline int kProf_Teamwork = 0x10;     // float, 0..1
-    inline int kProf_WeaponPref = 0x24;   // WORD[16] item def index, stride 2
-    inline int kProf_WeaponPrefCount = 0x44; // int
-    inline int kProf_Cost = 0x48;         // int
-    inline int kProf_Difficulty = 0x50;   // u8 bitflags EASY/NORMAL/HARD/EXPERT
-    inline int kProf_ReactionTime = 0x58; // float
-    inline int kProf_AttackDelay = 0x5C;  // float
-    inline int kProf_LookAccelAtk = 0x78; // float m_lookAngleMaxAccelAttacking
-    inline int kProf_LookStiffAtk = 0x7C; // float m_lookAngleStiffnessAttacking
-    inline int kProf_LookDampAtk = 0x80;  // float m_lookAngleDampingAttacking
-
-    // ---- BuyState (a1 in BuyState::OnUpdate) ----
-
-    // m_isInitialDelay (bool); rising edge each round = freshly entered BuyState
-    inline int kBuy_InitialDelay = 0x08;
-    // m_doneBuying (bool); set 1 to make vanilla skip the rest of buying
-    inline int kBuy_DoneBuying = 0x18;
+    inline int kProf_Aggression = 0x08;       // float, 0..1
+    inline int kProf_Skill = 0x0C;            // float, 0..1
+    inline int kProf_Teamwork = 0x10;         // float, 0..1
+    inline int kProf_WeaponPref = 0x24;       // WORD[16] item def index, stride 2
+    inline int kProf_WeaponPrefCount = 0x44;  // int
+    inline int kProf_Cost = 0x48;             // int
+    inline int kProf_Difficulty = 0x50;       // u8 bitflags EASY/NORMAL/HARD/EXPERT
+    inline int kProf_ReactionTime = 0x58;     // float
+    inline int kProf_AttackDelay = 0x5C;      // float
+    inline int kProf_LookAccelAtk = 0x78;     // float m_lookAngleMaxAccelAttacking
+    inline int kProf_LookStiffAtk = 0x7C;     // float m_lookAngleStiffnessAttacking
+    inline int kProf_LookDampAtk = 0x80;      // float m_lookAngleDampingAttacking
 
     // ---- CBaseEntity / CEntityIdentity ----
 
@@ -69,8 +62,19 @@ namespace BotController::targets
     inline int kPawn_OriginalController = 0xB84;
     // CCSPlayerPawn -> v_angle (QAngle)
     inline int kPawn_ViewAngle = 0xAB8;
+    // v_anglePrevious (QAngle) — keep first-person spectator/camera history aligned
+    inline int kPawn_ViewAnglePrevious = 0xAC4;
+    // m_ServerViewAngleChanges — embedded network vector consumed by local/observer camera view.
+    inline int kPawn_ServerViewAngleChanges = 0xA50;
     // m_angEyeAngles (QAngle) — written each replay tick alongside v_angle
     inline int kPawn_EyeAngles = 0x1340;
+
+    // ---- BuyState ----
+
+    // m_isInitialDelay; rising edge each round = freshly entered BuyState
+    inline int kBuy_InitialDelay = 0x08;
+    // m_doneBuying; set 1 to make vanilla skip the rest of buying
+    inline int kBuy_DoneBuying = 0x18;
 
     // ---- CCSPlayer_WeaponServices ----
 
@@ -91,6 +95,8 @@ namespace BotController::targets
     inline int kServices_Buttons = 88;       // states[0] (pressed)
     inline int kServices_Buttons1 = 88 + 8;  // states[1]
     inline int kServices_Buttons2 = 88 + 16; // states[2]
+    // m_vecOldViewAngles (QAngle)
+    inline int kServices_OldViewAngles = 0x240;
 
     // duck/ladder state
     inline int kServices_LadderNormal = 0x3F8; // Vector m_vecLadderNormal

--- a/src/plugin.cpp
+++ b/src/plugin.cpp
@@ -10,13 +10,14 @@
 #include <icvar.h>
 #include <convar.h>
 #include <interfaces/interfaces.h>
+#include <networkstringtabledefs.h>
 
 #include <nlohmann/json.hpp>
 
 #include "WeaponLocker.h"
-#include "BotController.h"
 #include "BuyController.h"
 #include "BuyControllerState.h"
+#include "BotController.h"
 #include "InputInjector.h"
 #include "MotionRecorder.h"
 #include "dispatch.h"
@@ -39,10 +40,10 @@ public:
 
     const char *GetAuthor() override { return "XBribo(๑•.•๑)"; }
     const char *GetName() override { return "BotController"; }
-    const char *GetDescription() override { return "Record & Replay and Lock CS2 bots."; }
+    const char *GetDescription() override { return "Record and Replay CS2 bots."; }
     const char *GetURL() override { return ""; }
     const char *GetLicense() override { return "GPLv3"; }
-    const char *GetVersion() override { return "0.4.7"; }
+    const char *GetVersion() override { return "0.4.5"; }
     const char *GetDate() override { return __DATE__; }
     const char *GetLogTag() override { return "BL"; }
 };
@@ -106,8 +107,14 @@ bool BotControllerPlugin::Load(PluginId id, ISmmAPI *ismm,
 
     // Engine interface used by console command output (ClientPrintf).
     BotController::Commands::g_pEngine = BotController::Dispatch::g_pEngine;
-
-    // Server-side command executor for issuing bot "buy" commands.
+    BotController::Commands::g_pStringTables = static_cast<INetworkStringTableContainer *>(
+        ismm->GetEngineFactory()(INTERFACENAME_NETWORKSTRINGTABLESERVER, nullptr));
+    if (!BotController::Commands::g_pStringTables)
+    {
+        BotController::DebugOut(
+            "[BotController] WARN: network string table server interface unavailable; "
+            "bc_avatar_override_probe disabled\n");
+    }
     BotController::Dispatch::g_pGameClients =
         static_cast<ISource2GameClients *>(serverIface);
 
@@ -145,7 +152,7 @@ bool BotControllerPlugin::Load(PluginId id, ISmmAPI *ismm,
         return false;
     }
 
-    // BuyController is optional; missing sig only disables buy control
+    // BuyController is optional; missing sig only disables buy control.
     char buyErr[256] = {0};
     if (!BotController::BuyControllerHooks::Install(gd, serverModule, buyErr, sizeof(buyErr)))
     {
@@ -188,6 +195,7 @@ bool BotControllerPlugin::Unload(char * /*error*/, size_t /*maxlen*/)
     BotController::Dispatch::g_pEngine = nullptr;
     BotController::Dispatch::g_pGameClients = nullptr;
     BotController::Commands::g_pEngine = nullptr;
+    BotController::Commands::g_pStringTables = nullptr;
     ConVar_Unregister();
     g_pCVar = nullptr;
     BotController::DebugOut("[BotController] plugin unloaded\n");


### PR DESCRIPTION
## Summary

- Improve BotController record/replay fidelity with extended replay buffers, command-frame input injection, replay slot state, bounded replay starts, first-person POV publishing controls, replay perf counters, and cleaner handoff state reset.
- Bump the native C ABI to 16 and expose ABI metadata, capability bits, and build id through the native exports, standalone P/Invoke wrapper, and shared CounterStrikeSharp capability API.
- Preserve upstream BotProfile support while adding the replay hooks, gamedata entries, CMake proto fallback, FUNCHOOK_ROOT support, and README updates.

## Notes

- Existing Linux gamedata was preserved. The new GetEyeAngles and PhysicsSimulate signatures are optional/fallback paths and are left blank for Linux until verified.
- This is intended as a generic BotController fidelity/runtime improvement, not a dependency on any downstream project.

## Validation

- `git diff --check`
- `dotnet build csharp/BotControllerImpl/BotControllerImpl.csproj -c Release`
  - Passed with NuGet NU1603 warnings because `CounterStrikeSharp.API` 1.0.365 resolved to 1.0.367.
- `cmake -S . -B build -G "Visual Studio 18 2026" -A x64`
- `cmake --build build --config Release`
  - Passed on Windows x64. MSBuild warned only that the build directory was under `%TEMP%`.