### PR TITLE
Update Windows targets for the 2026-07-09 CS2 update

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,6 +38,7 @@ set(PROTO_FILES
     networkbasetypes.proto
     source2_steam_stats.proto
     netmessages.proto
+    valveextensions.proto
     usercmd.proto
     cs_usercmd.proto)
 set(GENERATED_DIR "${CMAKE_BINARY_DIR}/generated")

--- a/configs/addons/BotController/gamedata.json
+++ b/configs/addons/BotController/gamedata.json
@@ -34,7 +34,7 @@
   "CCSBot::Update": {
     "signatures": {
       "library": "server",
-      "windows": "40 55 56 57 41 55 48 8D AC 24 ? ? ? ? 48 81 EC ? ? ? ? 48 8D 05",
+      "windows": "40 55 56 57 41 54 48 8D AC 24 ? ? ? ? 48 81 EC ? ? ? ? 48 8D 05 ? ? ? ? C6 81 ? ? ? ? 00",
       "linux": "55 48 8D 05 ? ? ? ? 48 8D 35 ? ? ? ? 48 89 E5 41 57 41 56 41 55 4C 8D AD ? ? ? ? 41 54 4C 89 EA 53 48 89 FB 48 81 EC ? ? ? ? C6 87 08 06 00 00 00"
     },
     "comment": "Per-tick decision entry; PathFollower + look-around + reaction + weapon."
@@ -42,7 +42,7 @@
   "CCSBot::Upkeep": {
     "signatures": {
       "library": "server",
-      "windows": "40 53 57 41 54 48 81 EC",
+      "windows": "48 89 5C 24 ? 48 89 6C 24 ? 56 57 41 56 48 83 EC ? 4C 8B F1 33 ED 48 8B 49 ? 48 39 A9 ? ? ? ?",
       "linux": "55 48 8D 05 ? ? ? ? 48 8D 35 ? ? ? ? 48 89 E5 41 55 41 54 48 8D 55 C0 53 48 89 FB 48 8D 3D"
     },
     "comment": "Per-frame view mBotntenance; UpdateLookAround + jitter + UpdateLookAngles."
@@ -104,17 +104,17 @@
   "CBasePlayerController::OnSimulateUserCommands": {
     "signatures": {
       "library": "server",
-      "windows": "40 55 53 56 57 41 54 41 56 48 8D AC 24 ? ? ? ? 48 81 EC",
+      "windows": "40 55 53 56 57 41 55 41 56 48 8D AC 24 08 F9 FF FF",
       "linux": "55 ? ? ? ? ? ? ? ? ? ? ? ? ? ? 48 89 E5 41 57 41 56 41 55 41 54 53 48 89 FB 48 8D 3D ? ? ? ? 48 81 EC ? 00 00 00"
     },
     "comment": "Per-tick controller usercmd simulation boundary,replay commits cursor after original."
   },
   "CCSBot::AiTickedFlag": {
     "offsets": {
-      "windows": 21196,
+      "windows": 1552,
       "linux": 1544
     },
-    "comment": "AI-ran-this-tick byte flag."
+    "comment": "AI-ran-this-tick byte flag (0x610)."
   },
   "CCSBot::Pawn": {
     "offsets": {
@@ -272,38 +272,38 @@
   },
   "CCSPlayerPawn::WeaponServices": {
     "offsets": {
-      "windows": 2560,
+      "windows": 2608,
       "linux": 3296
     },
-    "comment": "m_pWeaponServices (0xA00)."
+    "comment": "m_pWeaponServices (0xA30)."
   },
   "CCSPlayerPawn::Controller": {
     "offsets": {
-      "windows": 2944,
+      "windows": 2992,
       "linux": 3680
     },
-    "comment": "m_hController (0xB80)."
+    "comment": "m_hController (0xBB0)."
   },
   "CCSPlayerPawn::OriginalController": {
     "offsets": {
-      "windows": 2948,
+      "windows": 3364,
       "linux": 4044
     },
-    "comment": "m_hOriginalController (0xB84)."
+    "comment": "m_hOriginalController (0xD24)."
   },
   "CCSPlayerPawn::ViewAngle": {
     "offsets": {
-      "windows": 2744,
+      "windows": 2792,
       "linux": 3480
     },
-    "comment": "v_angle (0xAB8)."
+    "comment": "v_angle (0xAE8)."
   },
   "CCSPlayerPawn::EyeAngles": {
     "offsets": {
-      "windows": 4928,
+      "windows": 4968,
       "linux": 5648
     },
-    "comment": "m_angEyeAngles (0x1340)."
+    "comment": "m_angEyeAngles (0x1368)."
   },
   "CCSPlayer_WeaponServices::ActiveWeapon": {
     "offsets": {
@@ -314,10 +314,10 @@
   },
   "CBasePlayerWeapon::ItemDefIndex": {
     "offsets": {
-      "windows": 2528,
+      "windows": 2560,
       "linux": 3264
     },
-    "comment": "m_iItemDefinitionIndex (0x9E0)."
+    "comment": "m_iItemDefinitionIndex (0xA00)."
   },
   "CCSPlayer_MovementServices::Pawn": {
     "offsets": {
@@ -405,14 +405,14 @@
   },
   "vtidx::PlayerRunCommand": {
     "offsets": {
-      "windows": 22,
+      "windows": 25,
       "linux": 23
     },
     "comment": "CCSPlayer_MovementServices vtable index."
   },
   "vtidx::FinishMove": {
     "offsets": {
-      "windows": 35,
+      "windows": 38,
       "linux": 36
     },
     "comment": "CCSPlayer_MovementServices vtable index."

--- a/src/VoiceSender/VoiceSender.cpp
+++ b/src/VoiceSender/VoiceSender.cpp
@@ -119,7 +119,8 @@ namespace BotController
             for (int i = 0; i < packetOffsetCount; ++i)
                 voice->add_packet_offsets(packetOffsets[i]);
 
-            msg->set_client(senderClient);
+            msg->set_client_deprecated(senderClient);
+            msg->set_entity(senderClient);
             msg->set_proximity(false);
             if (senderXuid != 0)
                 msg->set_xuid(senderXuid);

--- a/src/common/version_targets.h
+++ b/src/common/version_targets.h
@@ -9,7 +9,7 @@ namespace BotController::targets
     // ---- CCSBot ----
 
     // AI-ran-this-tick byte flag; set to 1 to fake a completed tick
-    inline int kBot_AiTickedFlag = 21196;
+    inline int kBot_AiTickedFlag = 0x610;
     // CCSBot -> pawn (CCSPlayerPawn*)
     inline int kBot_Pawn = 0x18;
     // CCSBot -> m_profile (BotProfile*)
@@ -62,15 +62,15 @@ namespace BotController::targets
     // ---- CCSPlayerPawn ----
 
     // m_pWeaponServices
-    inline int kPawn_WeaponServices = 0xA00;
+    inline int kPawn_WeaponServices = 0xA30;
     // m_hController (CHandle)
-    inline int kPawn_Controller = 0xB80;
+    inline int kPawn_Controller = 0xBB0;
     // m_hOriginalController (CHandle)
-    inline int kPawn_OriginalController = 0xB84;
+    inline int kPawn_OriginalController = 0xD24;
     // CCSPlayerPawn -> v_angle (QAngle)
-    inline int kPawn_ViewAngle = 0xAB8;
+    inline int kPawn_ViewAngle = 0xAE8;
     // m_angEyeAngles (QAngle) — written each replay tick alongside v_angle
-    inline int kPawn_EyeAngles = 0x1340;
+    inline int kPawn_EyeAngles = 0x1368;
 
     // ---- CCSPlayer_WeaponServices ----
 
@@ -79,9 +79,9 @@ namespace BotController::targets
 
     // ---- CBasePlayerWeapon ----
 
-    // m_AttributeManager(0x958) -> m_Item(0x50) -> m_iItemDefinitionIndex(0x38),
+    // m_AttributeManager(0x978) -> m_Item(0x50) -> m_iItemDefinitionIndex(0x38),
     // all embedded; net direct add (no deref)
-    inline int kWeapon_ItemDefIndex = 0x958 + 0x50 + 0x38; // 0x9E0
+    inline int kWeapon_ItemDefIndex = 0x978 + 0x50 + 0x38; // 0xA00
 
     // ---- CCSPlayer_MovementServices ----
 
@@ -109,8 +109,8 @@ namespace BotController::targets
 
     // ---- vtable indices (CCSPlayer_MovementServices) ----
 
-    inline int kVtIdx_PlayerRunCommand = 22;
-    inline int kVtIdx_FinishMove = 35;
+    inline int kVtIdx_PlayerRunCommand = 25;
+    inline int kVtIdx_FinishMove = 38;
 
     // Override the above from gamedata[name].offsets[platform]; missing keeps default
     void LoadFromGamedata(const nlohmann::json &gd);


### PR DESCRIPTION
## Summary

- update the verified Windows signatures for `CCSBot::Update`, `CCSBot::Upkeep`, and `CBasePlayerController::OnSimulateUserCommands`
- update Windows bot, pawn, weapon, and movement-services vtable targets changed by the 2026-07-09 CS2 update
- generate the newly imported `valveextensions.proto` output and use the current voice-message field names

Linux signatures and offsets are intentionally unchanged.

## Why

The 2026-07-09 CS2 update shifted several Windows function prologues, schema-backed fields, and movement-services vtable entries. The previous targets either no longer matched or pointed at pre-update layouts.

## Validation

- each of the three updated Windows function signatures matches exactly once in the current Windows `server.dll` (SHA-256 `BDB81200C1FE8D2DB104210F041EAE2360A6432AC804BD8611C338A507B4A8D2`)
- `gamedata.json` parses successfully
- Windows x64 Release build succeeds with the current HL2SDK-CS2, Metamod:Source, and protoc 3.21.8 toolchain
- the updated targets were exercised in a downstream Windows replay integration with movement, cursor progression, and weapon selection working

## Follow-up notes

Two related structural changes are not represented as scalar target updates in this PR:

- the current scene-node path is `CBaseEntity + 0x30 -> CBodyComponent + 0x08`; the old direct `m_pGameSceneNode` path needs a code-level adjustment
- `CBasePlayerPawn::m_pMovementServices` is at `0xA70` and can be used to cross-check movement-services-to-pawn mapping where the component helper is insufficient