### PR TITLE
ci: manual build workflow with guarded releases

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,298 @@
+name: Build
+
+on:
+  workflow_dispatch:
+    inputs:
+      target:
+        description: "Which package to build"
+        type: choice
+        default: all
+        options:
+          - all
+          - mm-windows
+          - mm-linux
+          - css
+          - sw2
+      release:
+        description: "Create tag + GitHub release (requires target=all)"
+        type: boolean
+        default: false
+
+env:
+  # Native SDK sources. Pin refs to exact commits if your local checkouts
+  # diverge from upstream HEAD (recommended for reproducible builds).
+  HL2SDK_REPO: alliedmodders/hl2sdk
+  HL2SDK_REF: cs2
+  MMSOURCE_REPO: alliedmodders/metamod-source
+  MMSOURCE_REF: master
+  # CSGO_PROTO source — must contain the CS2 network protos
+  # (source2_steam_stats.proto, valveextensions.proto, ...).
+  PROTOBUFS_REPO: SteamDatabase/Protobufs
+  PROTOBUFS_REF: master
+  PROTOBUFS_SUBDIR: csgo
+
+jobs:
+  # ------------------------------------------------------------------- Guard
+  # Extracts the three version strings. On release runs it additionally
+  # enforces: target=all, all versions identical, tag not already published.
+  guard:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    outputs:
+      mm_version: ${{ steps.ver.outputs.mm }}
+      css_version: ${{ steps.ver.outputs.css }}
+      sw2_version: ${{ steps.ver.outputs.sw2 }}
+      version: ${{ steps.ver.outputs.unified }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Extract versions
+        id: ver
+        run: |
+          mm=$(sed -nE 's/.*GetVersion\(\) override \{ return "([^"]+)".*/\1/p' src/plugin.cpp | head -1)
+          css=$(sed -nE 's/.*ModuleVersion => "([^"]+)".*/\1/p' csharp/BotControllerImpl/BotControllerImplPlugin.cs | head -1)
+          sw2=$(sed -nE 's/.*Version = "([^"]+)".*/\1/p' csharp/BotControllerImplSW2/BotControllerImplSW2Plugin.cs | head -1)
+          echo "MM=$mm CSS=$css SW2=$sw2"
+          for v in "$mm" "$css" "$sw2"; do
+            test -n "$v" || { echo "::error::failed to extract a version string"; exit 1; }
+          done
+          {
+            echo "mm=$mm"
+            echo "css=$css"
+            echo "sw2=$sw2"
+          } >> "$GITHUB_OUTPUT"
+          if [ "$mm" = "$css" ] && [ "$css" = "$sw2" ]; then
+            echo "unified=$mm" >> "$GITHUB_OUTPUT"
+          else
+            echo "::warning::version mismatch: MM=$mm CSS=$css SW2=$sw2"
+            echo "unified=" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Release preconditions
+        if: inputs.release
+        env:
+          MM: ${{ steps.ver.outputs.mm }}
+          CSS: ${{ steps.ver.outputs.css }}
+          SW2: ${{ steps.ver.outputs.sw2 }}
+        run: |
+          if [ "${{ inputs.target }}" != "all" ]; then
+            echo "::error::release requires target=all (got '${{ inputs.target }}')"
+            exit 1
+          fi
+          if [ "$MM" != "$CSS" ] || [ "$CSS" != "$SW2" ]; then
+            echo "::error::version mismatch, refusing to release: MM=$MM CSS=$CSS SW2=$SW2"
+            exit 1
+          fi
+          if git ls-remote --tags origin "refs/tags/v$MM" | grep -q .; then
+            echo "::error::tag v$MM already exists — bump the version strings first"
+            exit 1
+          fi
+          echo "releasing v$MM"
+
+  # ----------------------------------------------------------------- MM win64
+  mm-windows:
+    if: inputs.target == 'all' || inputs.target == 'mm-windows'
+    needs: guard
+    runs-on: windows-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Checkout hl2sdk-cs2
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ env.HL2SDK_REPO }}
+          ref: ${{ env.HL2SDK_REF }}
+          path: deps/hl2sdk-cs2
+
+      - name: Checkout metamod-source
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ env.MMSOURCE_REPO }}
+          ref: ${{ env.MMSOURCE_REF }}
+          path: deps/metamod-source
+
+      - name: Checkout protobufs
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ env.PROTOBUFS_REPO }}
+          ref: ${{ env.PROTOBUFS_REF }}
+          path: deps/protobufs
+
+      - name: Install protoc 3.21.12
+        shell: bash
+        run: |
+          curl -fsSL -o protoc.zip \
+            https://github.com/protocolbuffers/protobuf/releases/download/v21.12/protoc-21.12-win64.zip
+          mkdir -p "$RUNNER_TEMP/protoc"
+          unzip -q protoc.zip -d "$RUNNER_TEMP/protoc"
+          echo "PROTOC=$RUNNER_TEMP/protoc/bin/protoc.exe" >> "$GITHUB_ENV"
+          "$RUNNER_TEMP/protoc/bin/protoc.exe" --version
+
+      - name: Configure + build
+        env:
+          HL2SDKCS2: ${{ github.workspace }}/deps/hl2sdk-cs2
+          MMSOURCE_DEV: ${{ github.workspace }}/deps/metamod-source
+          CSGO_PROTO: ${{ github.workspace }}/deps/protobufs/${{ env.PROTOBUFS_SUBDIR }}
+        run: |
+          cmake -B build -A x64 -S .
+          cmake --build build --config Release
+
+      - name: Verify output
+        shell: bash
+        run: test -f build/package/addons/BotController/bin/win64/BotController.dll
+
+      - name: Upload package
+        uses: actions/upload-artifact@v4
+        with:
+          name: BotController-MM-windows-${{ needs.guard.outputs.mm_version }}
+          path: build/package/
+          if-no-files-found: error
+
+  # ---------------------------------------------------------------- MM linux
+  mm-linux:
+    if: inputs.target == 'all' || inputs.target == 'mm-linux'
+    needs: guard
+    runs-on: ubuntu-24.04
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Checkout hl2sdk-cs2
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ env.HL2SDK_REPO }}
+          ref: ${{ env.HL2SDK_REF }}
+          path: deps/hl2sdk-cs2
+
+      - name: Checkout metamod-source
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ env.MMSOURCE_REPO }}
+          ref: ${{ env.MMSOURCE_REF }}
+          path: deps/metamod-source
+
+      - name: Checkout protobufs
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ env.PROTOBUFS_REPO }}
+          ref: ${{ env.PROTOBUFS_REF }}
+          path: deps/protobufs
+
+      - name: Install protoc 3.21.x
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y protobuf-compiler
+          protoc --version | grep -q 'libprotoc 3\.21\.'
+
+      - name: Configure + build
+        env:
+          HL2SDKCS2: ${{ github.workspace }}/deps/hl2sdk-cs2
+          MMSOURCE_DEV: ${{ github.workspace }}/deps/metamod-source
+          CSGO_PROTO: ${{ github.workspace }}/deps/protobufs/${{ env.PROTOBUFS_SUBDIR }}
+        run: |
+          cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
+          cmake --build build -j"$(nproc)"
+
+      - name: Verify output
+        run: test -f build/package/addons/BotController/bin/linuxsteamrt64/BotController.so
+
+      - name: Upload package
+        uses: actions/upload-artifact@v4
+        with:
+          name: BotController-MM-linux-${{ needs.guard.outputs.mm_version }}
+          path: build/package/
+          if-no-files-found: error
+
+  # -------------------------------------------------------- CounterStrikeSharp
+  css:
+    if: inputs.target == 'all' || inputs.target == 'css'
+    needs: guard
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 10.0.x
+
+      - name: Build
+        run: dotnet build csharp/BotControllerImpl -c Release
+
+      - name: Stage package
+        run: |
+          css=dist/CounterStrikeSharp/addons/counterstrikesharp
+          mkdir -p "$css/shared/BotControllerApi" "$css/plugins/BotControllerImpl"
+          cp csharp/BotControllerApi/bin/Release/BotControllerApi.dll "$css/shared/BotControllerApi/"
+          cp csharp/BotControllerImpl/bin/Release/BotControllerImpl.dll "$css/plugins/BotControllerImpl/"
+
+      - name: Upload package
+        uses: actions/upload-artifact@v4
+        with:
+          name: BotController-CSS-API-${{ needs.guard.outputs.css_version }}
+          path: dist/CounterStrikeSharp/
+          if-no-files-found: error
+
+  # ------------------------------------------------------------------ SwiftlyS2
+  sw2:
+    if: inputs.target == 'all' || inputs.target == 'sw2'
+    needs: guard
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 10.0.x
+
+      - name: Build
+        run: dotnet build csharp/BotControllerImplSW2 -c Release
+
+      - name: Stage package
+        run: |
+          sw2=dist/SwiftlyS2/addons/swiftlys2/plugins/BotControllerImplSW2
+          mkdir -p "$sw2"
+          cp -r csharp/BotControllerImplSW2/build/. "$sw2/"
+
+      - name: Upload package
+        uses: actions/upload-artifact@v4
+        with:
+          name: BotController-SW2-API-${{ needs.guard.outputs.sw2_version }}
+          path: dist/SwiftlyS2/
+          if-no-files-found: error
+
+  # ------------------------------------------------------------------- Release
+  # Creates tag v<version> at the built commit and publishes the four zips.
+  release:
+    if: inputs.release
+    needs: [guard, mm-windows, mm-linux, css, sw2]
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    permissions:
+      contents: write
+    steps:
+      - name: Download all packages
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+
+      - name: Zip packages
+        run: |
+          cd artifacts
+          for d in */; do
+            d="${d%/}"
+            (cd "$d" && zip -qr "../$d.zip" .)
+            echo "packed $d.zip"
+          done
+          ls -l ./*.zip
+
+      - name: Create tag + release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: v${{ needs.guard.outputs.version }}
+          target_commitish: ${{ github.sha }}
+          files: artifacts/*.zip
+          generate_release_notes: true
+          draft: false

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,7 +44,7 @@ jobs:
       sw2_version: ${{ steps.ver.outputs.sw2 }}
       version: ${{ steps.ver.outputs.unified }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Extract versions
         id: ver
@@ -96,24 +96,24 @@ jobs:
     runs-on: windows-latest
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Checkout hl2sdk-cs2
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           repository: ${{ env.HL2SDK_REPO }}
           ref: ${{ env.HL2SDK_REF }}
           path: deps/hl2sdk-cs2
 
       - name: Checkout metamod-source
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           repository: ${{ env.MMSOURCE_REPO }}
           ref: ${{ env.MMSOURCE_REF }}
           path: deps/metamod-source
 
       - name: Checkout protobufs
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           repository: ${{ env.PROTOBUFS_REPO }}
           ref: ${{ env.PROTOBUFS_REF }}
@@ -143,7 +143,7 @@ jobs:
         run: test -f build/package/addons/BotController/bin/win64/BotController.dll
 
       - name: Upload package
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: BotController-MM-windows-${{ needs.guard.outputs.mm_version }}
           path: build/package/
@@ -156,24 +156,24 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Checkout hl2sdk-cs2
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           repository: ${{ env.HL2SDK_REPO }}
           ref: ${{ env.HL2SDK_REF }}
           path: deps/hl2sdk-cs2
 
       - name: Checkout metamod-source
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           repository: ${{ env.MMSOURCE_REPO }}
           ref: ${{ env.MMSOURCE_REF }}
           path: deps/metamod-source
 
       - name: Checkout protobufs
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           repository: ${{ env.PROTOBUFS_REPO }}
           ref: ${{ env.PROTOBUFS_REF }}
@@ -198,7 +198,7 @@ jobs:
         run: test -f build/package/addons/BotController/bin/linuxsteamrt64/BotController.so
 
       - name: Upload package
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: BotController-MM-linux-${{ needs.guard.outputs.mm_version }}
           path: build/package/
@@ -211,9 +211,9 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-dotnet@v4
+      - uses: actions/setup-dotnet@v6
         with:
           dotnet-version: 10.0.x
 
@@ -228,7 +228,7 @@ jobs:
           cp csharp/BotControllerImpl/bin/Release/BotControllerImpl.dll "$css/plugins/BotControllerImpl/"
 
       - name: Upload package
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: BotController-CSS-API-${{ needs.guard.outputs.css_version }}
           path: dist/CounterStrikeSharp/
@@ -241,9 +241,9 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-dotnet@v4
+      - uses: actions/setup-dotnet@v6
         with:
           dotnet-version: 10.0.x
 
@@ -257,7 +257,7 @@ jobs:
           cp -r csharp/BotControllerImplSW2/build/. "$sw2/"
 
       - name: Upload package
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: BotController-SW2-API-${{ needs.guard.outputs.sw2_version }}
           path: dist/SwiftlyS2/
@@ -274,7 +274,7 @@ jobs:
       contents: write
     steps:
       - name: Download all packages
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: artifacts
 
@@ -289,7 +289,7 @@ jobs:
           ls -l ./*.zip
 
       - name: Create tag + release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: v${{ needs.guard.outputs.version }}
           target_commitish: ${{ github.sha }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -108,7 +108,6 @@ FetchContent_MakeAvailable(funchook)
 
 set(SDK_SOURCES
     ${HL2SDK}/public/tier0/memoverride.cpp
-    ${HL2SDK}/tier1/generichash.cpp
     ${HL2SDK}/tier1/keyvalues3.cpp
     ${HL2SDK}/tier1/convar.cpp
     ${MMS}/core/sourcehook/sourcehook.cpp
@@ -179,7 +178,6 @@ if(WIN32)
     target_link_libraries(BotController PRIVATE
         psapi
         ${HL2SDK_LIBDIR}/tier0.lib
-        ${HL2SDK_LIBDIR}/tier1.lib
         ${HL2SDK_LIBDIR}/mathlib.lib
         ${HL2SDK_LIBDIR}/interfaces.lib
         ${HL2SDK_LIBDIR}/2015/libprotobuf.lib
@@ -197,7 +195,6 @@ elseif(CMAKE_SYSTEM_NAME STREQUAL "Linux")
     set(HL2SDK_LIBDIR ${HL2SDK}/lib/linux64)
     target_link_libraries(BotController PRIVATE
         ${HL2SDK_LIBDIR}/libtier0.so
-        ${HL2SDK_LIBDIR}/tier1.a
         ${HL2SDK_LIBDIR}/mathlib.a
         ${HL2SDK_LIBDIR}/interfaces.a
         ${HL2SDK_LIBDIR}/release/libprotobuf.a


### PR DESCRIPTION
## Summary

Adds a manually triggered GitHub Actions workflow that builds each package independently, plus a guarded release flow that tags and publishes all four zips in one run.

- `workflow_dispatch` with a `target` choice: `all`, `mm-windows`, `mm-linux`, `css`, `sw2`
- Artifacts named per package with the version read from source at build time:
  - `BotController-MM-windows-<version>.zip` / `BotController-MM-linux-<version>.zip` (from `GetVersion()` in `src/plugin.cpp`)
  - `BotController-CSS-API-<version>.zip` (from `ModuleVersion`)
  - `BotController-SW2-API-<version>.zip` (from the SwiftlyS2 plugin `Version`)
- Optional `release` flag: builds everything, then creates tag `v<version>` at the built commit and publishes a GitHub release with the four zips. A guard job refuses to release when the three version strings disagree, when `target != all`, or when the tag already exists, so a release is just: bump versions, push, run the workflow with `release` checked.
- Native jobs check out `hl2sdk` (cs2), `metamod-source`, and SteamDatabase/Protobufs, and pin protoc to 3.21.x to match the CMake requirement. Repos/refs are workflow-level `env` vars, easy to repoint or pin to exact commits.
- All actions on their current node24 majors.

Also removes the tier1 source/link references from `CMakeLists.txt` that became obsolete after hl2sdk-cs2 made `generichash` header-only.

## Notes for review

- `CSGO_PROTO` defaults to the `csgo/` dir of SteamDatabase/Protobufs; adjust `PROTOBUFS_*` env vars if you source the protos elsewhere.
- The Linux job builds on `ubuntu-24.04`; if stricter glibc compatibility is wanted, the job can be switched to a SteamRT3 sniper container later.