### PR TITLE
Fix crashes and broken bot replay on Linux (tested on Docker, SteamRT3)

### DIFF
--- a/src/BotRecorder/InputInjector.cpp
+++ b/src/BotRecorder/InputInjector.cpp
@@ -25,7 +25,13 @@
 namespace tg = BotController::targets;
 
 using ProcessMovement_t = void(BC_FASTCALL*)(void* services, void* moveData);
+// On Linux this slot is (services, moveData); Windows adds a cmd argument.
+// Declaring that extra argument on Linux reads a stale register and crashes.
+#if defined(_WIN32)
 using FinishMove_t = void(BC_FASTCALL*)(void* services, void* cmd, void* moveData);
+#else
+using FinishMove_t = void(BC_FASTCALL*)(void* services, void* moveData);
+#endif
 using PlayerRunCommand_t = void(BC_FASTCALL*)(void* services, void* cmd);
 using PhysicsSimulate_t = void(BC_FASTCALL*)(void* controller);
 
@@ -360,7 +366,11 @@ static void BC_FASTCALL HookedProcessMovement(void* services, void* moveData)
 
 // ---- FinishMove: replay post-write + commit ----
 
+#if defined(_WIN32)
 static void BC_FASTCALL HookedFinishMove(void* services, void* cmd, void* moveData)
+#else
+static void BC_FASTCALL HookedFinishMove(void* services, void* moveData)
+#endif
 {
     g_finishMoveCalls.fetch_add(1, std::memory_order_relaxed);
     int slot = ServicesToSlot(services);
@@ -369,7 +379,11 @@ static void BC_FASTCALL HookedFinishMove(void* services, void* cmd, void* moveDa
     // Before original: write post snapshot into MoveData.
     if (replaying) MotionRecorder::OnReplayFinishMove(slot, services, moveData);
 
+#if defined(_WIN32)
     g_origFinishMove(services, cmd, moveData);
+#else
+    g_origFinishMove(services, moveData);
+#endif
 
     // After original: commit moveType/flags + advance the replay cursor
     if (replaying && !g_physicsActive)

--- a/src/BotRecorder/MotionRecorder.cpp
+++ b/src/BotRecorder/MotionRecorder.cpp
@@ -558,9 +558,13 @@ static void WriteVelocityToPawn(int slot, void* services, const MovementSnapshot
     WriteVector3(pawn, tg::kEnt_AbsVelocity, s.velX, s.velY, s.velZ);
 }
 
-// Writes replay origin through the current body-component scene node.
+// Writes the replay origin to the scene node (Windows only). On Linux
+// the movement pipeline already networks the position; a raw write here
+// would set only the local origin, not the networked one, and desync
+// the bot on clients.
 static void WriteSceneNodeOrigin(int slot, void* services, const MovementSnapshot& s, float zBias = 0.0f)
 {
+#if defined(_WIN32)
     void* pawn = InputInjector::ResolveReplayPawn(slot, services);
     if (!pawn) return;
 
@@ -568,6 +572,12 @@ static void WriteSceneNodeOrigin(int slot, void* services, const MovementSnapsho
     if (!node) return;
 
     WriteVector3(node, tg::kNode_AbsOrigin, s.originX, s.originY, s.originZ + zBias);
+#else
+    (void)slot;
+    (void)services;
+    (void)s;
+    (void)zBias;
+#endif
 }
 
 // Write origin + velocity into CMoveData.

--- a/src/common/ccsbot_slot.cpp
+++ b/src/common/ccsbot_slot.cpp
@@ -18,6 +18,9 @@
 #define NOMINMAX
 #endif
 #include <windows.h>
+#else
+#include <sys/uio.h>
+#include <unistd.h>
 #endif
 
 namespace tg = BotController::targets;
@@ -59,10 +62,14 @@ bool TryReadMemory(const void* base, int offset, void* out, size_t size)
     {
         return false;
     }
-#else
-    std::memcpy(out, reinterpret_cast<const void*>(address), size);
-#endif
     return true;
+#else
+    // Linux has no SEH: a bad pointer would SIGSEGV and take down the
+    // server. process_vm_readv lets the kernel reject it with EFAULT.
+    struct iovec local{ out, size };
+    struct iovec remote{ reinterpret_cast<void*>(address), size };
+    return process_vm_readv(getpid(), &local, 1, &remote, 1, 0) == static_cast<ssize_t>(size);
+#endif
 }
 
 // Writes an engine field and converts access violations into a failed update.
@@ -83,10 +90,13 @@ bool TryWriteMemory(void* base, int offset, const void* value, size_t size)
     {
         return false;
     }
-#else
-    std::memcpy(reinterpret_cast<void*>(address), value, size);
-#endif
     return true;
+#else
+    // See TryReadMemory: EFAULT instead of SIGSEGV for bad pointers.
+    struct iovec local{ const_cast<void*>(value), size };
+    struct iovec remote{ reinterpret_cast<void*>(address), size };
+    return process_vm_writev(getpid(), &local, 1, &remote, 1, 0) == static_cast<ssize_t>(size);
+#endif
 }
 
 PawnControllerHandles ReadPawnControllerHandles(void* pawn)


### PR DESCRIPTION
Linux-only. Windows paths are kept unchanged.

**Problem 1** - replaying a recording onto a bot crashes the server (segfault).
  Cause: on Linux the FinishMove vtable slot is (services, moveData), but the
  plugin declares it (services, cmd, moveData). So the 3rd parameter is a
  stale register and the replay writes through a garbage pointer.
  (Ghidra decompiles the function to 2 args - RDI=services, RSI=moveData;
  RDX is never read as input. Matches the crash core dump, where the 3rd arg
  slot held garbage.)
  Fix:
  - InputInjector: declare/call FinishMove with the Linux signature (2 args)

**Related hardening**: TryRead/WriteMemory are supposed to catch bad pointers, but the guard is an SEH __try/__except that only exists under #ifdef _WIN32. On Linux they fall back to a plain memcpy with no guard - which is why the bad pointer above took the server down instead of just failing. Both live in two central helpers, so this covers every guarded access at once.
  Fix:
  - ccsbot_slot: TryRead/WriteMemory use process_vm_readv/writev on Linux, so a bad pointer returns EFAULT instead of SIGSEGV

**Problem 2** - the bot replays but stays invisible: its visible body isn't synced
  to its actual position (server-side the position is correct, the client just
  never gets it).
  Cause: the replay writes the local scene-node origin (offset 200) only, not
  the networked cell-coordinate origin the client interpolates.
  Fix:
  - MotionRecorder: on Linux skip that raw origin write and let the movement pipeline set + network the position from the replayed input (Side note: unclear why the raw write is needed on Windows at all - that branch even carries a +1000 Z-bias workaround. Left as-is, Windows untested.)